### PR TITLE
Adding support for serverless, reacting to api changes, adding tests 

### DIFF
--- a/.github/workflows/dotnet-releaser.yaml
+++ b/.github/workflows/dotnet-releaser.yaml
@@ -27,5 +27,5 @@ jobs:
     - name: Run dotnet-releaser
       shell: bash
       run: |
-        dotnet user-secrets set "PineconeApiKey" "${{secrets.PINECONE_API_KEY}}"
+        dotnet user-secrets set "PineconeApiKey" "${{secrets.PINECONE_API_KEY}}" --project test
         dotnet-releaser run --nuget-token "${{secrets.NUGET_TOKEN}}" --github-token "${{secrets.GITHUB_TOKEN}}" dotnet-releaser.toml

--- a/.github/workflows/dotnet-releaser.yaml
+++ b/.github/workflows/dotnet-releaser.yaml
@@ -19,6 +19,7 @@ jobs:
       uses: actions/setup-dotnet@v2
       with:
         dotnet-version: |
+          6.0.x
           7.0.x
           8.0.x
     - name: CI/CD

--- a/.github/workflows/dotnet-releaser.yaml
+++ b/.github/workflows/dotnet-releaser.yaml
@@ -22,8 +22,10 @@ jobs:
           6.0.x
           7.0.x
           8.0.x
-    - name: CI/CD
+    - name: Install dotnet-releaser
+      run: dotnet tool install -g dotnet-releaser
+    - name: Run dotnet-releaser
       shell: bash
       run: |
-        dotnet tool install -g dotnet-releaser
+        dotnet user-secrets set "PineconeApiKey" "${{secrets.PINECONE_API_KEY}}"
         dotnet-releaser run --nuget-token "${{secrets.NUGET_TOKEN}}" --github-token "${{secrets.GITHUB_TOKEN}}" dotnet-releaser.toml

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,19 +1,17 @@
 {
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
     "version": "0.2.0",
     "configurations": [
         {
-            // Use IntelliSense to find out which attributes exist for C# debugging
-            // Use hover for the description of the existing attributes
-            // For further information visit https://github.com/OmniSharp/omnisharp-vscode/blob/master/debugger-launchjson.md
             "name": ".NET Core Launch (console)",
             "type": "coreclr",
             "request": "launch",
             "preLaunchTask": "build",
-            // If you have changed target frameworks, make sure to update the program path.
-            "program": "${workspaceFolder}/example/bin/Debug/net8.0/Example.dll",
+            "program": "${workspaceFolder}/example/Example.CSharp/bin/Debug/net8.0/Example.CSharp.dll",
             "args": [],
-            "cwd": "${workspaceFolder}/example",
-            // For more information about the 'console' field, see https://aka.ms/VSCode-CS-LaunchJson-Console
+            "cwd": "${workspaceFolder}/example/Example.CSharp",
             "console": "internalConsole",
             "stopAtEntry": false
         },

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -7,9 +7,9 @@
             "type": "process",
             "args": [
                 "build",
-                "${workspaceFolder}/example/Example.csproj",
+                "${workspaceFolder}/example/Example.CSharp/Example.CSharp.csproj",
                 "/property:GenerateFullPaths=true",
-                "/consoleloggerparameters:NoSummary"
+                "/consoleloggerparameters:NoSummary;ForceNoAlign"
             ],
             "problemMatcher": "$msCompile"
         },
@@ -19,9 +19,9 @@
             "type": "process",
             "args": [
                 "publish",
-                "${workspaceFolder}/example/Example.csproj",
+                "${workspaceFolder}/example/Example.CSharp/Example.CSharp.csproj",
                 "/property:GenerateFullPaths=true",
-                "/consoleloggerparameters:NoSummary"
+                "/consoleloggerparameters:NoSummary;ForceNoAlign"
             ],
             "problemMatcher": "$msCompile"
         },
@@ -33,7 +33,7 @@
                 "watch",
                 "run",
                 "--project",
-                "${workspaceFolder}/example/Example.csproj"
+                "${workspaceFolder}/example/Example.CSharp/Example.CSharp.csproj"
             ],
             "problemMatcher": "$msCompile"
         }

--- a/Pinecone.sln
+++ b/Pinecone.sln
@@ -9,6 +9,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Example.CSharp", "example\E
 EndProject
 Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "Example.FSharp", "example\Example.FSharp\Example.FSharp.fsproj", "{48198DC6-2D75-417F-8096-9FF9AC657511}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PineconeTests", "test\PineconeTests.csproj", "{122FC8A9-A7F9-43DA-A67E-4148D07B9597}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -27,6 +29,10 @@ Global
 		{48198DC6-2D75-417F-8096-9FF9AC657511}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{48198DC6-2D75-417F-8096-9FF9AC657511}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{48198DC6-2D75-417F-8096-9FF9AC657511}.Release|Any CPU.Build.0 = Release|Any CPU
+		{122FC8A9-A7F9-43DA-A67E-4148D07B9597}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{122FC8A9-A7F9-43DA-A67E-4148D07B9597}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{122FC8A9-A7F9-43DA-A67E-4148D07B9597}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{122FC8A9-A7F9-43DA-A67E-4148D07B9597}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/example/Example.CSharp/Example.CSharp.csproj
+++ b/example/Example.CSharp/Example.CSharp.csproj
@@ -9,6 +9,11 @@
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <PublishAot>true</PublishAot>
+    <InvariantGlobalization>true</InvariantGlobalization>
+  </PropertyGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\..\src\Pinecone.csproj" />
   </ItemGroup>

--- a/example/Example.CSharp/Program.cs
+++ b/example/Example.CSharp/Program.cs
@@ -11,7 +11,7 @@ var indexList = await pinecone.ListIndexes();
 if (!indexList.Select(x => x.Name).Contains(indexName))
 {
     // free serverless indexes are currently only available on AWS us-east-1
-    await pinecone.CreateServerlessIndexAsync(indexName, 1536, Metric.Cosine, "aws", "us-east-1");
+    await pinecone.CreateServerlessIndex(indexName, 1536, Metric.Cosine, "aws", "us-east-1");
 }
 
 // Get the Pinecone index by name (uses gRPC by default).

--- a/example/Example.CSharp/Program.cs
+++ b/example/Example.CSharp/Program.cs
@@ -1,16 +1,17 @@
 using Pinecone;
 
-using var pinecone = new PineconeClient("[api-key]", "[pinecone-env]");
+using var pinecone = new PineconeClient("[api-key]");
 
 // Check if the index exists and create it if it doesn't
 // Depending on the storage type and infrastructure state this may take a while
-// Free tier is limited to 1 index only
+// Free tier is limited to 1 pod index and 5 serverless indexes only
 var indexName = "test-index";
 var indexList = await pinecone.ListIndexes();
 
-if (!indexList.Contains(indexName))
+if (!indexList.Select(x => x.Name).Contains(indexName))
 {
-    await pinecone.CreateIndex(indexName, 1536, Metric.Cosine);
+    // free serverless indexes are currently only available on AWS us-east-1
+    await pinecone.CreateServerlessIndexAsync(indexName, 1536, Metric.Cosine, "aws", "us-east-1");
 }
 
 // Get the Pinecone index by name (uses gRPC by default).

--- a/example/Example.FSharp/Program.fs
+++ b/example/Example.FSharp/Program.fs
@@ -1,4 +1,5 @@
-﻿open Pinecone
+﻿#nowarn "3391"
+open Pinecone
 open System.Collections.Generic
 
 let createMetadata x =
@@ -14,7 +15,7 @@ let main = task {
     let! indexList = pinecone.ListIndexes()
     if not (indexList |> Array.exists (fun index -> index.Name = indexName)) then
         // free serverless indexes are currently only available on AWS us-east-1
-        pinecone.CreateServerlessIndex(indexName, 1536u, Metric.Cosine, "aws", "us-east-1")
+        do! pinecone.CreateServerlessIndex(indexName, 1536u, Metric.Cosine, "aws", "us-east-1")
 
     // Get the Pinecone index by name (uses gRPC by default).
     // The index client is thread-safe, consider caching and/or

--- a/example/Example.FSharp/Program.fs
+++ b/example/Example.FSharp/Program.fs
@@ -13,8 +13,8 @@ let main = task {
     let indexName = "test-index"
     let! indexList = pinecone.ListIndexes()
     if not (indexList |> Array.exists (fun index -> index.Name = indexName)) then
-        // Create the serverless index (available only on AWS us-east-1)
-        pinecone.CreateServerlessIndexAsync(indexName, 1536u, Metric.Cosine, "aws", "us-east-1")
+        // free serverless indexes are currently only available on AWS us-east-1
+        pinecone.CreateServerlessIndex(indexName, 1536u, Metric.Cosine, "aws", "us-east-1")
 
     // Get the Pinecone index by name (uses gRPC by default).
     // The index client is thread-safe, consider caching and/or

--- a/src/Extensions.cs
+++ b/src/Extensions.cs
@@ -7,15 +7,17 @@ namespace Pinecone;
 internal static class Extensions
 {
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    internal static ValueTask CheckStatusCode(this HttpResponseMessage response, [CallerMemberName] string requestName = "")
+    internal static ValueTask CheckStatusCode(
+        this HttpResponseMessage response, CancellationToken ct, [CallerMemberName] string requestName = "")
     {
-        return response.IsSuccessStatusCode ? ValueTask.CompletedTask : ThrowOnFailedResponse(response, requestName);
+        return response.IsSuccessStatusCode ? ValueTask.CompletedTask : ThrowOnFailedResponse(response, requestName, ct);
 
         [DoesNotReturn, StackTraceHidden]
-        static async ValueTask ThrowOnFailedResponse(HttpResponseMessage response, string requestName)
+        static async ValueTask ThrowOnFailedResponse(
+            HttpResponseMessage response, string requestName, CancellationToken ct)
         {
             throw new HttpRequestException($"{requestName} request has failed. " +
-                $"Code: {response.StatusCode}. Message: {await response.Content.ReadAsStringAsync().ConfigureAwait(false)}");
+                $"Code: {response.StatusCode}. Message: {await response.Content.ReadAsStringAsync(ct).ConfigureAwait(false)}");
         }
     }
 }

--- a/src/Grpc/GrpcTransport.cs
+++ b/src/Grpc/GrpcTransport.cs
@@ -33,10 +33,8 @@ public readonly record struct GrpcTransport : ITransport<GrpcTransport>
         }
 
         using var call = Grpc.DescribeIndexStatsAsync(request, Auth);
-        var response = await call.ConfigureAwait(false);
         
-        return response.ToPublicType();
-        //return (await call.ConfigureAwait(false)).ToPublicType();
+        return (await call.ConfigureAwait(false)).ToPublicType();
     }
 
     public async Task<ScoredVector[]> Query(
@@ -92,10 +90,8 @@ public readonly record struct GrpcTransport : ITransport<GrpcTransport>
         request.Vectors.AddRange(vectors.Select(v => v.ToProtoVector()));
 
         using var call = Grpc.UpsertAsync(request, Auth);
-        var response = await call.ConfigureAwait(false);
 
-        return response.UpsertedCount;
-        //return (await call.ConfigureAwait(false)).UpsertedCount;
+        return (await call.ConfigureAwait(false)).UpsertedCount;
     }
 
     public Task Update(Vector vector, string? indexNamespace = null) => Update(

--- a/src/Grpc/GrpcTransport.cs
+++ b/src/Grpc/GrpcTransport.cs
@@ -33,7 +33,10 @@ public readonly record struct GrpcTransport : ITransport<GrpcTransport>
         }
 
         using var call = Grpc.DescribeIndexStatsAsync(request, Auth);
-        return (await call.ConfigureAwait(false)).ToPublicType();
+        var response = await call.ConfigureAwait(false);
+        
+        return response.ToPublicType();
+        //return (await call.ConfigureAwait(false)).ToPublicType();
     }
 
     public async Task<ScoredVector[]> Query(
@@ -89,7 +92,10 @@ public readonly record struct GrpcTransport : ITransport<GrpcTransport>
         request.Vectors.AddRange(vectors.Select(v => v.ToProtoVector()));
 
         using var call = Grpc.UpsertAsync(request, Auth);
-        return (await call.ConfigureAwait(false)).UpsertedCount;
+        var response = await call.ConfigureAwait(false);
+
+        return response.UpsertedCount;
+        //return (await call.ConfigureAwait(false)).UpsertedCount;
     }
 
     public Task Update(Vector vector, string? indexNamespace = null) => Update(

--- a/src/ITransport.cs
+++ b/src/ITransport.cs
@@ -33,7 +33,7 @@ public interface ITransport<
     }
 #endif
 
-    Task<IndexStats> DescribeStats(MetadataMap? filter = null);
+    Task<IndexStats> DescribeStats(MetadataMap? filter = null, CancellationToken ct = default);
     Task<ScoredVector[]> Query(
         string? id,
         float[]? values,
@@ -42,17 +42,19 @@ public interface ITransport<
         MetadataMap? filter,
         string? indexNamespace,
         bool includeValues,
-        bool includeMetadata);
-    Task<uint> Upsert(IEnumerable<Vector> vectors, string? indexNamespace = null);
-    Task Update(Vector vector, string? indexNamespace = null);
+        bool includeMetadata,
+        CancellationToken ct = default);
+    Task<uint> Upsert(IEnumerable<Vector> vectors, string? indexNamespace = null, CancellationToken ct = default);
+    Task Update(Vector vector, string? indexNamespace = null, CancellationToken ct = default);
     Task Update(
         string id,
         float[]? values = null,
         SparseVector? sparseValues = null,
         MetadataMap? metadata = null,
-        string? indexNamespace = null);
-    Task<Dictionary<string, Vector>> Fetch(IEnumerable<string> ids, string? indexNamespace = null);
-    Task Delete(IEnumerable<string> ids, string? indexNamespace = null);
-    Task Delete(MetadataMap filter, string? indexNamespace = null);
-    Task DeleteAll(string? indexNamespace = null);
+        string? indexNamespace = null,
+        CancellationToken ct = default);
+    Task<Dictionary<string, Vector>> Fetch(IEnumerable<string> ids, string? indexNamespace = null, CancellationToken ct = default);
+    Task Delete(IEnumerable<string> ids, string? indexNamespace = null, CancellationToken ct = default);
+    Task Delete(MetadataMap filter, string? indexNamespace = null, CancellationToken ct = default);
+    Task DeleteAll(string? indexNamespace = null, CancellationToken ct = default);
 }

--- a/src/Index.cs
+++ b/src/Index.cs
@@ -61,9 +61,9 @@ public sealed partial record Index<TTransport> : IDisposable
     /// </summary>
     /// <param name="filter">The operation only returns statistics for vectors that satisfy the filter.</param>
     /// <returns>An <see cref="IndexStats"/> object containing index statistics.</returns>
-    public Task<IndexStats> DescribeStats(MetadataMap? filter = null)
+    public Task<IndexStats> DescribeStats(MetadataMap? filter = null, CancellationToken ct = default)
     {
-        return Transport.DescribeStats(filter);
+        return Transport.DescribeStats(filter, ct);
     }
 
     /// <summary>
@@ -71,8 +71,6 @@ public sealed partial record Index<TTransport> : IDisposable
     /// </summary>
     /// <remarks>Query by ID uses Approximate Nearest Neighbor, which doesn't guarantee the input vector to appear in the results. To ensure that, use the Fetch operation instead.</remarks>
     /// <param name="id">The unique ID of the vector to be used as a query vector.</param>
-    /// <param name="values">The query vector. This should be the same length as the dimension of the index being queried.</param>
-    /// <param name="sparseValues">Vector sparse data. Represented as a list of indices and a list of corresponded values, which must be with the same length.</param>
     /// <param name="topK">The number of results to return for each query.</param>
     /// <param name="filter">The filter to apply.</param>
     /// <param name="indexNamespace">Namespace to query from. If no namespace is provided, the operation applies to all namespaces.</param>
@@ -85,7 +83,8 @@ public sealed partial record Index<TTransport> : IDisposable
         MetadataMap? filter = null,
         string? indexNamespace = null,
         bool includeValues = true,
-        bool includeMetadata = false)
+        bool includeMetadata = false,
+        CancellationToken ct = default)
     {
         return Transport.Query(
             id: id,
@@ -95,7 +94,8 @@ public sealed partial record Index<TTransport> : IDisposable
             filter: filter,
             indexNamespace: indexNamespace,
             includeValues: includeValues,
-            includeMetadata: includeMetadata);
+            includeMetadata: includeMetadata,
+            ct: ct);
     }
 
     /// <summary>
@@ -116,7 +116,8 @@ public sealed partial record Index<TTransport> : IDisposable
         SparseVector? sparseValues = null,
         string? indexNamespace = null,
         bool includeValues = true,
-        bool includeMetadata = false)
+        bool includeMetadata = false,
+        CancellationToken ct = default)
     {
         return Transport.Query(
             id: null,
@@ -126,7 +127,8 @@ public sealed partial record Index<TTransport> : IDisposable
             filter: filter,
             indexNamespace: indexNamespace,
             includeValues: includeValues,
-            includeMetadata: includeMetadata);
+            includeMetadata: includeMetadata,
+            ct: ct);
     }
 
     /// <summary>
@@ -135,9 +137,9 @@ public sealed partial record Index<TTransport> : IDisposable
     /// <param name="vectors">A collection of <see cref="Vector"/> objects to upsert.</param>
     /// <param name="indexNamespace">Namespace to write the vector to. If no namespace is provided, the operation applies to all namespaces.</param>
     /// <returns>The number of vectors upserted.</returns>
-    public Task<uint> Upsert(IEnumerable<Vector> vectors, string? indexNamespace = null)
+    public Task<uint> Upsert(IEnumerable<Vector> vectors, string? indexNamespace = null, CancellationToken ct = default)
     {
-        return Transport.Upsert(vectors, indexNamespace);
+        return Transport.Upsert(vectors, indexNamespace, ct);
     }
 
     /// <summary>
@@ -145,9 +147,9 @@ public sealed partial record Index<TTransport> : IDisposable
     /// </summary>
     /// <param name="vector"><see cref="Vector"/> object containing updated information.</param>
     /// <param name="indexNamespace">Namespace to update the vector from. If no namespace is provided, the operation applies to all namespaces.</param>
-    public Task Update(Vector vector, string? indexNamespace = null)
+    public Task Update(Vector vector, string? indexNamespace = null, CancellationToken ct = default)
     {
-        return Transport.Update(vector, indexNamespace);
+        return Transport.Update(vector, indexNamespace, ct);
     }
 
     /// <summary>
@@ -163,9 +165,10 @@ public sealed partial record Index<TTransport> : IDisposable
         float[]? values = null,
         SparseVector? sparseValues = null,
         MetadataMap? metadata = null,
-        string? indexNamespace = null)
+        string? indexNamespace = null,
+        CancellationToken ct = default)
     {
-        return Transport.Update(id, values, sparseValues, metadata, indexNamespace);
+        return Transport.Update(id, values, sparseValues, metadata, indexNamespace, ct);
     }
 
     /// <summary>
@@ -174,9 +177,9 @@ public sealed partial record Index<TTransport> : IDisposable
     /// <param name="ids">IDs of vectors to fetch.</param>
     /// <param name="indexNamespace">Namespace to fetch vectors from. If no namespace is provided, the operation applies to all namespaces.</param>
     /// <returns>A dictionary containing vector IDs and the corresponding <see cref="Vector"/> objects containing the vector information.</returns>
-    public Task<Dictionary<string, Vector>> Fetch(IEnumerable<string> ids, string? indexNamespace = null)
+    public Task<Dictionary<string, Vector>> Fetch(IEnumerable<string> ids, string? indexNamespace = null, CancellationToken ct = default)
     {
-        return Transport.Fetch(ids, indexNamespace);
+        return Transport.Fetch(ids, indexNamespace, ct);
     }
 
     /// <summary>
@@ -184,9 +187,9 @@ public sealed partial record Index<TTransport> : IDisposable
     /// </summary>
     /// <param name="ids"></param>
     /// <param name="indexNamespace">Namespace to delete vectors from. If no namespace is provided, the operation applies to all namespaces.</param>
-    public Task Delete(IEnumerable<string> ids, string? indexNamespace = null)
+    public Task Delete(IEnumerable<string> ids, string? indexNamespace = null, CancellationToken ct = default)
     {
-        return Transport.Delete(ids, indexNamespace);
+        return Transport.Delete(ids, indexNamespace, ct);
     }
 
     /// <summary>
@@ -194,18 +197,18 @@ public sealed partial record Index<TTransport> : IDisposable
     /// </summary>
     /// <param name="filter">Filter used to select vectors to delete.</param>
     /// <param name="indexNamespace">Namespace to delete vectors from. If no namespace is provided, the operation applies to all namespaces.</param>
-    public Task Delete(MetadataMap filter, string? indexNamespace = null)
+    public Task Delete(MetadataMap filter, string? indexNamespace = null, CancellationToken ct = default)
     {
-        return Transport.Delete(filter, indexNamespace);
+        return Transport.Delete(filter, indexNamespace, ct);
     }
 
     /// <summary>
     /// Deletes all vectors.
     /// </summary>
     /// <param name="indexNamespace">Namespace to delete vectors from. If no namespace is provided, the operation applies to all namespaces.</param>
-    public Task DeleteAll(string? indexNamespace = null)
+    public Task DeleteAll(string? indexNamespace = null, CancellationToken ct = default)
     {
-        return Transport.DeleteAll(indexNamespace);
+        return Transport.DeleteAll(indexNamespace, ct);
     }
 
     /// <inheritdoc />

--- a/src/Index.cs
+++ b/src/Index.cs
@@ -54,7 +54,7 @@ public sealed partial record Index<TTransport> : IDisposable
     /// The transport layer.
     /// </summary>
     [JsonIgnore]
-    internal TTransport Transport { get; set; } = default!;
+    public required TTransport Transport { private get; init; }
 
     /// <summary>
     /// Returns statistics describing the contents of an index, including the vector count per namespace and the number of dimensions, and the index fullness.

--- a/src/Index.cs
+++ b/src/Index.cs
@@ -10,26 +10,75 @@ public sealed partial record Index<
 #endif
     TTransport> where TTransport : ITransport<TTransport>
 {
+    /// <summary>
+    /// Name of the index.
+    /// </summary>
     public required string Name { get; init; }
+
+    /// <summary>
+    /// The dimension of the vectors stored in the index.
+    /// </summary>
     public required uint Dimension { get; init; }
+
+    /// <summary>
+    /// The distance metric to be used for similarity search.
+    /// </summary>
     public required Metric Metric { get; init; }
+
+    /// <summary>
+    /// The URL address where the index is hosted.
+    /// </summary>
     public string? Host { get; init; }
+    
+    /// <summary>
+    /// Additional information about the index.
+    /// </summary>
     public required IndexSpec Spec { get; init; }
+    
+    /// <summary>
+    /// The current status of the index.
+    /// </summary>
     public required IndexStatus Status { get; init; }
 }
 
 // Implementation
+
+/// <summary>
+/// An object used for interacting with vectors. It is used to upsert, query, fetch, update, delete and list vectors, as well as retrieving index statistics.
+/// </summary>
+/// <typeparam name="TTransport">The type of transport layer used.</typeparam>
 public sealed partial record Index<TTransport> : IDisposable
     where TTransport : ITransport<TTransport>
 {
+    /// <summary>
+    /// The transport layer.
+    /// </summary>
     [JsonIgnore]
     internal TTransport Transport { get; set; } = default!;
 
+    /// <summary>
+    /// Returns statistics describing the contents of an index, including the vector count per namespace and the number of dimensions, and the index fullness.
+    /// </summary>
+    /// <param name="filter">The operation only returns statistics for vectors that satisfy the filter.</param>
+    /// <returns>An <see cref="IndexStats"/> object containing index statistics.</returns>
     public Task<IndexStats> DescribeStats(MetadataMap? filter = null)
     {
         return Transport.DescribeStats(filter);
     }
 
+    /// <summary>
+    /// Searches an index using the values of a vector with specified ID. It retrieves the IDs of the most similar items, along with their similarity scores.
+    /// </summary>
+    /// <remarks>Query by ID uses Approximate Nearest Neighbor, which doesn't guarantee the input vector to appear in the results. To ensure that, use the Fetch operation instead.</remarks>
+    /// <param name="id">The unique ID of the vector to be used as a query vector.</param>
+    /// <param name="values">The query vector. This should be the same length as the dimension of the index being queried.</param>
+    /// <param name="sparseValues">Vector sparse data. Represented as a list of indices and a list of corresponded values, which must be with the same length.</param>
+    /// <param name="topK">The number of results to return for each query.</param>
+    /// <param name="filter">The filter to apply.</param>
+    /// <param name="indexNamespace">Namespace to query from. If no namespace is provided, the operation applies to all namespaces.</param>
+    /// <param name="includeValues">Indicates whether vector values are included in the response.</param>
+    /// <param name="includeMetadata">Indicates whether metadata is included in the response as well as the IDs.</param>
+    /// <returns></returns>
     public Task<ScoredVector[]> Query(
         string id,
         uint topK,
@@ -49,6 +98,17 @@ public sealed partial record Index<TTransport> : IDisposable
             includeMetadata: includeMetadata);
     }
 
+    /// <summary>
+    /// Searches an index using the specified vector values. It retrieves the IDs of the most similar items, along with their similarity scores.
+    /// </summary>
+    /// <param name="values">The query vector. This should be the same length as the dimension of the index being queried.</param>
+    /// <param name="sparseValues">Vector sparse data. Represented as a list of indices and a list of corresponded values, which must be with the same length.</param>
+    /// <param name="topK">The number of results to return for each query.</param>
+    /// <param name="filter">The filter to apply.</param>
+    /// <param name="indexNamespace">Namespace to query from. If no namespace is provided, the operation applies to all namespaces.</param>
+    /// <param name="includeValues">Indicates whether vector values are included in the response.</param>
+    /// <param name="includeMetadata">Indicates whether metadata is included in the response as well as the IDs.</param>
+    /// <returns></returns>
     public Task<ScoredVector[]> Query(
         float[] values,
         uint topK,
@@ -69,16 +129,35 @@ public sealed partial record Index<TTransport> : IDisposable
             includeMetadata: includeMetadata);
     }
 
+    /// <summary>
+    /// Writes vector into the index. If a new value is provided for an existing vector ID, it will overwrite the previous value.
+    /// </summary>
+    /// <param name="vectors">A collection of <see cref="Vector"/> objects to upsert.</param>
+    /// <param name="indexNamespace">Namespace to write the vector to. If no namespace is provided, the operation applies to all namespaces.</param>
+    /// <returns>The number of vectors upserted.</returns>
     public Task<uint> Upsert(IEnumerable<Vector> vectors, string? indexNamespace = null)
     {
         return Transport.Upsert(vectors, indexNamespace);
     }
 
+    /// <summary>
+    /// Updates a vector using the <see cref="Vector"/> object.
+    /// </summary>
+    /// <param name="vector"><see cref="Vector"/> object containing updated information.</param>
+    /// <param name="indexNamespace">Namespace to update the vector from. If no namespace is provided, the operation applies to all namespaces.</param>
     public Task Update(Vector vector, string? indexNamespace = null)
     {
         return Transport.Update(vector, indexNamespace);
     }
 
+    /// <summary>
+    /// Updates a vector.
+    /// </summary>
+    /// <param name="id">The ID of the vector to update.</param>
+    /// <param name="values">New vector values.</param>
+    /// <param name="sparseValues">New vector sparse data. </param>
+    /// <param name="metadata">New vector metadata.</param>
+    /// <param name="indexNamespace">Namespace to update the vector from. If no namespace is provided, the operation applies to all namespaces.</param>
     public Task Update(
         string id,
         float[]? values = null,
@@ -89,25 +168,46 @@ public sealed partial record Index<TTransport> : IDisposable
         return Transport.Update(id, values, sparseValues, metadata, indexNamespace);
     }
 
+    /// <summary>
+    /// Looks up and returns vectors, by ID. The returned vectors include the vector data and/or metadata.
+    /// </summary>
+    /// <param name="ids">IDs of vectors to fetch.</param>
+    /// <param name="indexNamespace">Namespace to fetch vectors from. If no namespace is provided, the operation applies to all namespaces.</param>
+    /// <returns>A dictionary containing vector IDs and the corresponding <see cref="Vector"/> objects containing the vector information.</returns>
     public Task<Dictionary<string, Vector>> Fetch(IEnumerable<string> ids, string? indexNamespace = null)
     {
         return Transport.Fetch(ids, indexNamespace);
     }
 
+    /// <summary>
+    /// Deletes vectors with specified ids.
+    /// </summary>
+    /// <param name="ids"></param>
+    /// <param name="indexNamespace">Namespace to delete vectors from. If no namespace is provided, the operation applies to all namespaces.</param>
     public Task Delete(IEnumerable<string> ids, string? indexNamespace = null)
     {
         return Transport.Delete(ids, indexNamespace);
     }
 
+    /// <summary>
+    /// Deletes vectors based on metadata filter provided.
+    /// </summary>
+    /// <param name="filter">Filter used to select vectors to delete.</param>
+    /// <param name="indexNamespace">Namespace to delete vectors from. If no namespace is provided, the operation applies to all namespaces.</param>
     public Task Delete(MetadataMap filter, string? indexNamespace = null)
     {
         return Transport.Delete(filter, indexNamespace);
     }
 
+    /// <summary>
+    /// Deletes all vectors.
+    /// </summary>
+    /// <param name="indexNamespace">Namespace to delete vectors from. If no namespace is provided, the operation applies to all namespaces.</param>
     public Task DeleteAll(string? indexNamespace = null)
     {
         return Transport.DeleteAll(indexNamespace);
     }
 
+    /// <inheritdoc />
     public void Dispose() => Transport.Dispose();
 }

--- a/src/Index.cs
+++ b/src/Index.cs
@@ -10,9 +10,11 @@ public sealed partial record Index<
 #endif
     TTransport> where TTransport : ITransport<TTransport>
 {
-    [JsonPropertyName("database")]
-    public required IndexDetails Details { get; init; }
-
+    public required string Name { get; init; }
+    public required uint Dimension { get; init; }
+    public required Metric Metric { get; init; }
+    public string? Host { get; init; }
+    public required IndexSpec Spec { get; init; }
     public required IndexStatus Status { get; init; }
 }
 

--- a/src/Pinecone.csproj
+++ b/src/Pinecone.csproj
@@ -19,6 +19,7 @@ In the absence of an official SDK, it provides first-class support for Pinecone 
     <ImplicitUsings>enable</ImplicitUsings>
     <LangVersion>12</LangVersion>
     <Nullable>enable</Nullable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetFramework)' == 'net6.0'">

--- a/src/Pinecone.csproj
+++ b/src/Pinecone.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <PackageId>Pinecone.NET</PackageId>
-    <Authors>neon-sunset</Authors>
+    <Authors>neon-sunset, maumar</Authors>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <RepositoryUrl>https://github.com/neon-sunset/Pinecone.NET</RepositoryUrl>
     <PackageProjectUrl>https://github.com/neon-sunset/Pinecone.NET</PackageProjectUrl>

--- a/src/PineconeClient.cs
+++ b/src/PineconeClient.cs
@@ -149,13 +149,12 @@ public sealed class PineconeClient : IDisposable
 #endif
         where TTransport : ITransport<TTransport>
     {
-        var response = (IndexDetails)(await Http
+        var response = await Http
             .GetFromJsonAsync(
                 $"/indexes/{UrlEncoder.Default.Encode(name)}",
-                typeof(IndexDetails),
-                SerializerContext.Default,
+                SerializerContext.Default.IndexDetails,
                 cancellationToken)
-            .ConfigureAwait(false) ?? throw new HttpRequestException("GetIndex request has failed."));
+            .ConfigureAwait(false) ?? throw new HttpRequestException("GetIndex request has failed.");
 
         // TODO: Host is optional according to the API spec: https://docs.pinecone.io/reference/api/control-plane/describe_index
         // but Transport requires it
@@ -170,13 +169,12 @@ public sealed class PineconeClient : IDisposable
             Host = response.Host,
             Spec = response.Spec,
             Status = response.Status,
-        };
-
 #if NET7_0_OR_GREATER
-        index.Transport = TTransport.Create(host, apiKey);
+            Transport = TTransport.Create(host, apiKey)
 #else
-        index.Transport = ITransport<TTransport>.Create(host, apiKey);
+            Transport = ITransport<TTransport>.Create(host, apiKey)
 #endif
+        };
 
         return index;
     }

--- a/src/PineconeClient.cs
+++ b/src/PineconeClient.cs
@@ -84,9 +84,9 @@ public sealed class PineconeClient : IDisposable
         Metric metric, 
         string environment, 
         string podType = "p1.x1", 
-        long? pods = 1, 
-        long? shards = 1, 
-        long? replicas = 1, 
+        uint? pods = 1, 
+        uint? shards = 1, 
+        uint? replicas = 1, 
         CancellationToken cancellationToken = default)
         => CreateIndexAsync(new CreateIndexRequest
         {

--- a/src/Rest/SerializerContext.cs
+++ b/src/Rest/SerializerContext.cs
@@ -25,6 +25,8 @@ namespace Pinecone.Rest;
 [JsonSerializable(typeof(DeleteRequest))]
 [JsonSerializable(typeof(MetadataMap))]
 [JsonSerializable(typeof(MetadataValue[]))]
+[JsonSerializable(typeof(ListIndexesResult))]
+[JsonSerializable(typeof(ListCollectionsResult))]
 [JsonSourceGenerationOptions(
     GenerationMode = JsonSourceGenerationMode.Default,
     PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,

--- a/src/Rest/Types.cs
+++ b/src/Rest/Types.cs
@@ -2,24 +2,12 @@ using System.Text.Json.Serialization;
 
 namespace Pinecone.Rest;
 
-internal sealed record CreateIndexRequest : IndexDetails
+internal sealed record CreateIndexRequest
 {
-    [JsonPropertyName("source_collection")]
-    public string? SourceCollection { get; init; }
-
-    public static CreateIndexRequest From(
-        IndexDetails index,
-        string? sourceCollection) => new()
-    {
-        Dimension = index.Dimension,
-        Metric = index.Metric,
-        Name = index.Name,
-        Pods = index.Pods,
-        PodType = index.PodType,
-        Replicas = index.Replicas,
-        MetadataConfig = index.MetadataConfig,
-        SourceCollection = sourceCollection
-    };
+    public required string Name { get; init; }
+    public required uint Dimension { get; init; }
+    public required Metric Metric { get; init; }
+    public required IndexSpec Spec { get; init; }
 }
 
 internal readonly record struct ConfigureIndexRequest

--- a/src/Rest/Types.cs
+++ b/src/Rest/Types.cs
@@ -2,6 +2,11 @@ using System.Text.Json.Serialization;
 
 namespace Pinecone.Rest;
 
+internal sealed record ListIndexesResult
+{
+    public required IndexDetails[] Indexes { get; init; }
+}
+
 internal sealed record CreateIndexRequest
 {
     public required string Name { get; init; }

--- a/src/Types/CollectionTypes.cs
+++ b/src/Types/CollectionTypes.cs
@@ -2,12 +2,25 @@ using System.Text.Json.Serialization;
 
 namespace Pinecone;
 
+public record ListCollectionsResult
+{
+    public required CollectionDetails[] Collections { get; init; }
+}
+
 public record CollectionDetails
 {
     public required string Name { get; init; }
-    public required long Size { get; init; }
-    public required string Status { get; init; }
-    public required long Dimension { get; init; }
+    public long? Size { get; init; }
+    public required CollectionStatus Status { get; init; }
+    public required uint Dimension { get; init; }
     [JsonPropertyName("vector_count")]
     public required long VectorCount { get; init; }
+    public required string Environment { get; init; }
+}
+
+public enum CollectionStatus
+{
+    Initializing = 0,
+    Ready = 1,
+    Terminating = 2
 }

--- a/src/Types/IndexTypes.cs
+++ b/src/Types/IndexTypes.cs
@@ -3,17 +3,20 @@ using Pinecone.Rest;
 
 namespace Pinecone;
 
+public record ListIndexesResult
+{
+    public required IndexDetails[] Indexes { get; init; }
+}
+
 public record IndexDetails
 {
     public required string Name { get; init; }
     public required uint Dimension { get; init; }
     public required Metric Metric { get; init; }
-    public long? Pods { get; init; }
-    [JsonPropertyName("pod_type")]
-    public string? PodType { get; init; }
-    public long? Replicas { get; init; }
-    [JsonPropertyName("metadata_config")]
-    public MetadataMap? MetadataConfig { get; init; }
+    public string? Host { get; init; }
+
+    public required IndexSpec Spec { get; init;}
+    public required IndexStatus Status { get; init; }
 }
 
 [JsonConverter(typeof(JsonStringEnumConverter<Metric>))]
@@ -29,10 +32,6 @@ public record IndexStatus
     [JsonPropertyName("ready")]
     public required bool IsReady { get; init; }
     public required IndexState State { get; init; }
-    public required string Host { get; init; }
-    public required int Port { get; init; }
-    public string?[]? Waiting { get; init; }
-    public string?[]? Crashed { get; init; }
 }
 
 [JsonConverter(typeof(JsonStringEnumConverter<IndexState>))]
@@ -46,6 +45,35 @@ public enum IndexState
     ScalingUpPodSize = 5,
     ScalingDownPodSize = 6,
     InitializationFailed = 7
+}
+
+public record IndexSpec
+{
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public ServerlessSpec? Serverless { get; init; }
+    
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public PodSpec? Pod { get; init; }
+}
+
+public record ServerlessSpec
+{
+    public required string Cloud { get; init; }
+    public required string Region { get; init; }
+}
+
+public record PodSpec
+{
+    [JsonPropertyName("environment")]
+    public required string Environment { get; init; }
+    public long? Replicas { get; init; }
+    [JsonPropertyName("pod_type")]
+    public required string PodType { get; init; }
+    public long Pods { get; init; }
+    [JsonPropertyName("metadata_config")]
+    public MetadataMap? MetadataConfig { get; init; }
+    [JsonPropertyName("source_collection")]
+    public string? SourceCollection { get; init; }
 }
 
 public record IndexStats

--- a/src/Types/IndexTypes.cs
+++ b/src/Types/IndexTypes.cs
@@ -149,19 +149,19 @@ public record PodSpec
     /// The number of pods used.
     /// </summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    public long? Pods { get; init; }
+    public uint? Pods { get; init; }
 
     /// <summary>
     /// The number od replicas.
     /// </summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    public long? Replicas { get; init; }
+    public uint? Replicas { get; init; }
 
     /// <summary>
     /// The number of shards.
     /// </summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    public long? Shards { get; init; }
+    public uint? Shards { get; init; }
 
     /// <summary>
     /// Configuration for the behavior of internal metadata index. By default, all metadata is indexed. 

--- a/src/Types/IndexTypes.cs
+++ b/src/Types/IndexTypes.cs
@@ -3,37 +3,84 @@ using Pinecone.Rest;
 
 namespace Pinecone;
 
-public record ListIndexesResult
-{
-    public required IndexDetails[] Indexes { get; init; }
-}
-
+/// <summary>
+/// Object storing information about the index.
+/// </summary>
 public record IndexDetails
 {
+    /// <summary>
+    /// Name of the index.
+    /// </summary>
     public required string Name { get; init; }
+
+    /// <summary>
+    /// The dimension of the indexed vectors.
+    /// </summary>
     public required uint Dimension { get; init; }
+
+    /// <summary>
+    /// The distance metric used for similarity search.
+    /// </summary>
     public required Metric Metric { get; init; }
+
+    /// <summary>
+    /// The URL address where the index is hosted.
+    /// </summary>
     public string? Host { get; init; }
 
+    /// <summary>
+    /// Additional information about the index.
+    /// </summary>
     public required IndexSpec Spec { get; init;}
+
+    /// <summary>
+    /// The current status of the index.
+    /// </summary>
     public required IndexStatus Status { get; init; }
 }
 
+/// <summary>
+/// The distance metric used for similarity search.
+/// </summary>
 [JsonConverter(typeof(JsonStringEnumConverter<Metric>))]
 public enum Metric
 {
+    /// <summary>
+    /// A measure of the angle between two vectors. It is computed by taking the dot product of the vectors and dividing it by the product of their magnitudes.
+    /// </summary>
     [JsonPropertyName("cosine")] Cosine = 0,
+
+    /// <summary>
+    /// Calculated by adding the products of the vectors' corresponding components.
+    /// </summary>
     [JsonPropertyName("dotproduct")] DotProduct = 1,
+
+    /// <summary>
+    /// Straight-line distance between two vectors in a multidimensional space.
+    /// </summary>
     [JsonPropertyName("euclidean")] Euclidean = 2
 }
 
+/// <summary>
+/// Current status of the index.
+/// </summary>
 public record IndexStatus
 {
+    /// <summary>
+    /// A value indicating whether the index is ready.
+    /// </summary>
     [JsonPropertyName("ready")]
     public required bool IsReady { get; init; }
+
+    /// <summary>
+    /// Current state of the index.
+    /// </summary>
     public required IndexState State { get; init; }
 }
 
+/// <summary>
+/// Current state of the index.
+/// </summary>
 [JsonConverter(typeof(JsonStringEnumConverter<IndexState>))]
 public enum IndexState
 {
@@ -47,46 +94,130 @@ public enum IndexState
     InitializationFailed = 7
 }
 
+/// <summary>
+/// Index specification.
+/// </summary>
 public record IndexSpec
 {
+    /// <summary>
+    /// Serverless index specification. <see langword="null" /> if the index is pod-based.
+    /// </summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public ServerlessSpec? Serverless { get; init; }
-    
+
+    /// <summary>
+    /// Pod-based index specification. <see langword="null" /> if the index is serverless.
+    /// </summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public PodSpec? Pod { get; init; }
 }
 
+/// <summary>
+/// Serverless index specification.
+/// </summary>
 public record ServerlessSpec
 {
+    /// <summary>
+    /// The public cloud where the index is hosted.
+    /// </summary>
     public required string Cloud { get; init; }
+
+    /// <summary>
+    /// The region where the index has been created.
+    /// </summary>
     public required string Region { get; init; }
 }
 
+/// <summary>
+/// Pod-based index specification.
+/// </summary>
 public record PodSpec
 {
+    /// <summary>
+    /// The environment where the index is hosted.
+    /// </summary>
     [JsonPropertyName("environment")]
     public required string Environment { get; init; }
-    public long? Replicas { get; init; }
+
+    /// <summary>
+    /// The pod type.
+    /// </summary>
     [JsonPropertyName("pod_type")]
     public required string PodType { get; init; }
-    public long Pods { get; init; }
+
+    /// <summary>
+    /// The number of pods used.
+    /// </summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public long? Pods { get; init; }
+
+    /// <summary>
+    /// The number od replicas.
+    /// </summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public long? Replicas { get; init; }
+
+    /// <summary>
+    /// The number of shards.
+    /// </summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public long? Shards { get; init; }
+
+    /// <summary>
+    /// Configuration for the behavior of internal metadata index. By default, all metadata is indexed. 
+    /// When MetadataConfig is present, only specified metadata fields are indexed.
+    /// </summary>
     [JsonPropertyName("metadata_config")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public MetadataMap? MetadataConfig { get; init; }
+
+    /// <summary>
+    /// The name of the collection used as the source for the index.
+    /// </summary>
     [JsonPropertyName("source_collection")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public string? SourceCollection { get; init; }
 }
 
+/// <summary>
+/// Statistics describing the contents of an index.
+/// </summary>
 public record IndexStats
 {
+    /// <summary>
+    /// List of namespaces.
+    /// </summary>
     [JsonConverter(typeof(IndexNamespaceArrayConverter))]
     public required IndexNamespace[] Namespaces { get; init; }
+
+    /// <summary>
+    /// The dimension of the indexed vectors.
+    /// </summary>
     public required uint Dimension { get; init; }
+
+    /// <summary>
+    /// The fullness of the index, regardless of whether a metadata filter expression was passed.
+    /// </summary>
     public required float IndexFullness { get; init; }
+    
+    /// <summary>
+    /// Total number of vectors stored in the index.
+    /// </summary>
     public required uint TotalVectorCount { get; init; }
 }
 
+/// <summary>
+/// Information about a single namespace.
+/// </summary>
 public readonly record struct IndexNamespace
 {
+    /// <summary>
+    /// Namespace name.
+    /// </summary>
     public required string Name { get; init; }
+
+    /// <summary>
+    /// Number of vectors stored in the namespace.
+    /// </summary>
     public required uint VectorCount { get; init; }
 }

--- a/src/Types/VectorTypes.cs
+++ b/src/Types/VectorTypes.cs
@@ -4,38 +4,105 @@ using Pinecone.Rest;
 
 namespace Pinecone;
 
+/// <summary>
+/// An object representing a vector.
+/// </summary>
 public record Vector
 {
+    /// <summary>
+    /// Unique ID of the vector.
+    /// </summary>
     public required string Id { get; init; }
+
+    /// <summary>
+    /// Vector data.
+    /// </summary>
     public required float[] Values { get; init; }
+
+    /// <summary>
+    /// Sparse vector information.
+    /// </summary>
     public SparseVector? SparseValues { get; init; }
+
+    /// <summary>
+    /// Metadata associated with this vector.
+    /// </summary>
     public MetadataMap? Metadata { get; init; }
 }
 
+/// <summary>
+/// Contains sparse vector information.
+/// </summary>
 public readonly record struct SparseVector
 {
+    /// <summary>
+    /// The indices of the sparse data.
+    /// </summary>
     public required uint[] Indices { get; init; }
+
+    /// <summary>
+    /// The corresponding values of the sparse data, which must be with the same length as the indices.
+    /// </summary>
     public required float[] Values { get; init; }
 }
 
+/// <summary>
+/// Vector returned as a result of a query operation. Contains regular vector information as well as similarity score.
+/// </summary>
 public record ScoredVector
 {
+    /// <summary>
+    /// Unique ID of the vector.
+    /// </summary>
     public required string Id { get; init; }
+
+    /// <summary>
+    /// This is a measure of similarity between this vector and the query vector. The higher the score, the more they are similar.
+    /// </summary>
     public required double Score { get; init; }
+
+    /// <summary>
+    /// Vector data.
+    /// </summary>
     public float[]? Values { get; init; }
+
+    /// <summary>
+    /// Sparse vector information.
+    /// </summary>
     public SparseVector? SparseValues { get; init; }
+
+    /// <summary>
+    /// Metadata associated with this vector.
+    /// </summary>
     public MetadataMap? Metadata { get; init; }
 }
 
+/// <summary>
+/// Collection of metadata consisting of key-value-pairs of property names and their corresponding values.
+/// </summary>
 public sealed class MetadataMap : Dictionary<string, MetadataValue> 
 {
+    /// <summary>
+    /// Creates a new instance of the <see cref="MetadataMap" /> class.
+    /// </summary>
     public MetadataMap() : base() { }
+
+    /// <summary>
+    /// Creates a new instance of the <see cref="MetadataMap" /> class from an existing collection.
+    /// </summary>
+    /// <param name="collection"></param>
     public MetadataMap(IEnumerable<KeyValuePair<string, MetadataValue>> collection) : base(collection) { }
 }
 
+/// <summary>
+/// Value corresponding to a metadata property.
+/// </summary>
 [JsonConverter(typeof(MetadataValueConverter))]
 public readonly record struct MetadataValue
 {
+    /// <summary>
+    /// Metadata value stored.
+    /// </summary>
     public object? Inner { get; }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/test/DataTestBase.cs
+++ b/test/DataTestBase.cs
@@ -16,9 +16,9 @@ public abstract class DataTestBase<TFixture>(TFixture fixture) : IClassFixture<T
 
         var results = await Fixture.Index.Query(
             [x * 0.1f, x * 0.2f, x * 0.3f, x * 0.4f, x * 0.5f, x * 0.6f, x * 0.7f, x * 0.8f],
-            topK: 10);
+            topK: 20);
 
-        Assert.Equal(8, results.Length);
+        Assert.Equal(10, results.Length);
 
         results =
             await Fixture.Index.Query(
@@ -138,6 +138,22 @@ public abstract class DataTestBase<TFixture>(TFixture fixture) : IClassFixture<T
         Assert.Equal("basic-vector-3", orderedResults[1].Key);
         Assert.Equal("basic-vector-3", orderedResults[1].Value.Id);
         Assert.Equal([1.5f, 3.0f, 4.5f, 6.0f, 7.5f, 9.0f, 10.5f, 12.0f], orderedResults[1].Value.Values);
+    }
+
+    [PineconeFact]
+    public async Task Fetch_sparse_vector()
+    {
+        var results = await Fixture.Index.Fetch(["sparse-1"]);
+
+        Assert.Single(results);
+        Assert.True(results.ContainsKey("sparse-1"));
+        var resultVector = results["sparse-1"];
+
+        Assert.Equal("sparse-1", resultVector.Id);
+        Assert.Equal([5, 10, 15, 20, 25, 30, 35, 40], resultVector.Values);
+        Assert.NotNull(resultVector.SparseValues);
+        Assert.Equal([1, 4], resultVector.SparseValues.Value.Indices);
+        Assert.Equal([0.2f, 0.5f], resultVector.SparseValues.Value.Values);
     }
 
     [PineconeFact]

--- a/test/DataTestFixtureBase.cs
+++ b/test/DataTestFixtureBase.cs
@@ -1,0 +1,165 @@
+﻿using Pinecone;
+using Pinecone.Grpc;
+using Xunit;
+
+namespace PineconeTests;
+public abstract class DataTestFixtureBase : IAsyncLifetime
+{
+    public const int MaxAttemptCount = 100;
+    public const int DelayInterval = 300;
+
+    protected abstract string IndexName { get; }
+
+    public PineconeClient Pinecone { get; private set; } = null!;
+
+    public virtual Index<GrpcTransport> Index { get; set; } = null!;
+
+    public virtual async Task InitializeAsync()
+    {
+        Pinecone = new PineconeClient(UserSecretsExtensions.ReadPineconeApiKey());
+
+        await ClearIndexesAsync();
+        await CreateIndexAndWait();
+        await AddSampleDataAsync();
+    }
+
+    protected abstract Task CreateIndexAndWait();
+
+    public async Task DisposeAsync()
+    {
+        if (Pinecone is not null)
+        {
+            await ClearIndexesAsync();
+            Pinecone.Dispose();
+        }
+    }
+
+    private async Task AddSampleDataAsync()
+    {
+        var basicVectors = Enumerable.Range(1, 5).Select(i => new Vector
+        {
+            Id = "basic-vector-" + i,
+            Values = [i * 0.5f, i * 1.0f, i * 1.5f, i * 2.0f, i * 2.5f, i * 3.0f, i * 3.5f, i * 4.0f],
+        }).ToList();
+
+        await InsertAndWait(basicVectors);
+
+        var customNamespaceVectors = Enumerable.Range(1, 3).Select(i => new Vector
+        {
+            Id = "custom-namespace-vector-" + i,
+            Values = [i * 1.1f, i * 2.2f, i * 3.3f, i * 4.4f, i * 5.5f, i * 6.6f, i * 7.7f, i * 8.8f],
+        }).ToList();
+
+        await InsertAndWait(customNamespaceVectors, "namespace1");
+
+        var metadata1 = new MetadataMap
+        {
+            ["type"] = "number set",
+            ["subtype"] = "primes",
+            ["rank"] = 3,
+            ["overhyped"] = false,
+            ["list"] = new string[] { "2", "1" },
+        };
+
+        var metadata2 = new MetadataMap
+        {
+            ["type"] = "number set",
+            ["subtype"] = "fibo",
+            ["list"] = new string[] { "0", "1" },
+        };
+
+        var metadata3 = new MetadataMap
+        {
+            ["type"] = "number set",
+            ["subtype"] = "lucas",
+            ["rank"] = 12,
+            ["overhyped"] = false,
+            ["list"] = new string[] { "two", "one" },
+        };
+
+        var metadataVectors = new Vector[]
+        {
+                new() { Id = "metadata-vector-1", Values = [2, 3, 5, 7, 11, 13, 17, 19], Metadata = metadata1 },
+                new() { Id = "metadata-vector-2", Values = [0, 1, 1, 2, 3, 5, 8, 13], Metadata = metadata2 },
+                new() { Id = "metadata-vector-3", Values = [2, 1, 3, 4, 7, 11, 18, 29], Metadata = metadata3 },
+        };
+
+        await InsertAndWait(metadataVectors);
+    }
+
+    public virtual async Task<uint> InsertAndWait(IEnumerable<Vector> vectors, string? indexNamespace = null)
+    {
+        // NOTE: this only works when inserting *new* vectors, if the vector already exisits the new vector count won't match
+        // and we will have false-negative "failure" to insert
+        var stats = await Index.DescribeStats();
+        var vectorCountBefore = stats.TotalVectorCount;
+        var attemptCount = 0;
+        var result = await Index.Upsert(vectors, indexNamespace);
+
+        do
+        {
+            await Task.Delay(DelayInterval);
+            attemptCount++;
+            stats = await Index.DescribeStats();
+        } while (stats.TotalVectorCount < vectorCountBefore + vectors.Count() && attemptCount <= MaxAttemptCount);
+
+        if (stats.TotalVectorCount < vectorCountBefore + vectors.Count())
+        {
+            throw new InvalidOperationException("'Upsert' operation didn't complete in time. Vectors count: " + vectors.Count());
+        }
+
+        return result;
+    }
+
+    public async Task DeleteAndWait(IEnumerable<string> ids, string? indexNamespace = null)
+    {
+        var stats = await Index.DescribeStats();
+        var vectorCountBefore = stats.Namespaces.Single(x => x.Name == (indexNamespace ?? "")).VectorCount;
+
+        var attemptCount = 0;
+        await Index.Delete(ids, indexNamespace);
+        long vectorCount;
+        do
+        {
+            await Task.Delay(DelayInterval);
+            attemptCount++;
+            stats = await Index.DescribeStats();
+            vectorCount = stats.Namespaces.Single(x => x.Name == (indexNamespace ?? "")).VectorCount;
+        } while (vectorCount > vectorCountBefore - ids.Count() && attemptCount <= MaxAttemptCount);
+
+        if (vectorCount > vectorCountBefore - ids.Count())
+        {
+            throw new InvalidOperationException("'Delete' operation didn't complete in time.");
+        }
+    }
+
+    private async Task ClearIndexesAsync()
+    {
+        foreach (var existingIndex in await Pinecone.ListIndexes())
+        {
+            await DeleteExistingIndexAndWaitAsync(existingIndex.Name);
+        }
+    }
+
+    private async Task DeleteExistingIndexAndWaitAsync(string indexName)
+    {
+        var exists = true;
+        var attemptCount = 0;
+        await Pinecone.DeleteIndex(indexName);
+
+        do
+        {
+            await Task.Delay(DelayInterval);
+            var indexes = (await Pinecone.ListIndexes()).Select(x => x.Name).ToArray();
+            if (indexes.Length == 0 || !indexes.Contains(indexName))
+            {
+                exists = false;
+            }
+        } while (exists && attemptCount <= MaxAttemptCount);
+
+        if (exists)
+        {
+            throw new InvalidOperationException("'Delete index' operation didn't complete in time. Index name: " + indexName);
+        }
+    }
+}

--- a/test/DataTestFixtureBase.cs
+++ b/test/DataTestFixtureBase.cs
@@ -79,12 +79,20 @@ public abstract class DataTestFixtureBase : IAsyncLifetime
 
         var metadataVectors = new Vector[]
         {
-                new() { Id = "metadata-vector-1", Values = [2, 3, 5, 7, 11, 13, 17, 19], Metadata = metadata1 },
-                new() { Id = "metadata-vector-2", Values = [0, 1, 1, 2, 3, 5, 8, 13], Metadata = metadata2 },
-                new() { Id = "metadata-vector-3", Values = [2, 1, 3, 4, 7, 11, 18, 29], Metadata = metadata3 },
+            new() { Id = "metadata-vector-1", Values = [2, 3, 5, 7, 11, 13, 17, 19], Metadata = metadata1 },
+            new() { Id = "metadata-vector-2", Values = [0, 1, 1, 2, 3, 5, 8, 13], Metadata = metadata2 },
+            new() { Id = "metadata-vector-3", Values = [2, 1, 3, 4, 7, 11, 18, 29], Metadata = metadata3 },
         };
 
         await InsertAndWait(metadataVectors);
+
+        var sparseVectors = new Vector[]
+        {
+            new() { Id = "sparse-1", Values = [5, 10, 15, 20, 25, 30, 35, 40], SparseValues = new() { Indices = [1, 4], Values = [0.2f, 0.5f] } },
+            new() { Id = "sparse-2", Values = [15, 110, 115, 120, 125, 130, 135, 140], SparseValues = new() { Indices = [2, 3], Values = [0.5f, 0.8f] } },
+        };
+
+        await InsertAndWait(sparseVectors);
     }
 
     public virtual async Task<uint> InsertAndWait(IEnumerable<Vector> vectors, string? indexNamespace = null)

--- a/test/DataTestFixtureBase.cs
+++ b/test/DataTestFixtureBase.cs
@@ -143,10 +143,10 @@ public abstract class DataTestFixtureBase : IAsyncLifetime
 
     private async Task ClearIndexesAsync()
     {
-        foreach (var existingIndex in await Pinecone.ListIndexes())
-        {
-            await DeleteExistingIndexAndWaitAsync(existingIndex.Name);
-        }
+        var indexes = await Pinecone.ListIndexes();
+        var deletions = indexes.Select(x => DeleteExistingIndexAndWaitAsync(x.Name));
+
+        await Task.WhenAll(deletions);
     }
 
     private async Task DeleteExistingIndexAndWaitAsync(string indexName)

--- a/test/DataTestFixtureBase.cs
+++ b/test/DataTestFixtureBase.cs
@@ -143,10 +143,10 @@ public abstract class DataTestFixtureBase : IAsyncLifetime
 
     private async Task ClearIndexesAsync()
     {
-        var indexes = await Pinecone.ListIndexes();
-        var deletions = indexes.Select(x => DeleteExistingIndexAndWaitAsync(x.Name));
-
-        await Task.WhenAll(deletions);
+        foreach (var existingIndex in await Pinecone.ListIndexes())
+        {
+            await DeleteExistingIndexAndWaitAsync(existingIndex.Name);
+        }
     }
 
     private async Task DeleteExistingIndexAndWaitAsync(string indexName)

--- a/test/DataTests.cs
+++ b/test/DataTests.cs
@@ -1,0 +1,419 @@
+﻿using Pinecone;
+using Pinecone.Grpc;
+using Xunit;
+
+namespace PineconeTests;
+
+[Collection("PineconeTests")]
+public class DataTests(DataTests.TestFixture fixture) : IClassFixture<DataTests.TestFixture>
+{
+    private TestFixture Fixture { get; } = fixture;
+
+    [Fact]
+    public async Task Basic_query()
+    {
+        var x = 0.314f;
+
+        var results = await Fixture.Index.Query(
+            [x * 0.1f, x * 0.2f, x * 0.3f, x * 0.4f, x * 0.5f, x * 0.6f, x * 0.7f, x * 0.8f],
+            topK: 10);
+
+        Assert.Equal(8, results.Length);
+
+        results =
+            await Fixture.Index.Query(
+                [0.7f, 7.7f, 77.7f, 777.7f, 7777.7f, 77777.7f, 777777.7f, 7777777.7f],
+                topK: 10, 
+                indexNamespace: "namespace1");
+
+        Assert.Equal(3, results.Length);
+    }
+
+    [Fact]
+    public async Task Query_by_Id()
+    {
+        var result = await Fixture.Index.Query("basic-vector-3", topK: 2);
+
+        // NOTE: query by id uses Approximate Nearest Neighbor, which doesn't guarantee the input vector
+        // to appear in the results, so we just check the result count
+        Assert.Equal(2, result.Length);
+    }
+
+    [Fact]
+    public async Task Query_with_basic_metadata_filter()
+    {
+        var filter = new MetadataMap
+        {
+            ["type"] = "number set"
+        };
+
+        var result = await Fixture.Index.Query([3, 4, 5, 6, 7, 8, 9, 10], topK: 5, filter);
+
+        Assert.Equal(3, result.Length);
+        var ordered = result.OrderBy(x => x.Id).ToList();
+
+        Assert.Equal("metadata-vector-1", ordered[0].Id);
+        Assert.Equal([2, 3, 5, 7, 11, 13, 17, 19], ordered[0].Values);
+        Assert.Equal("metadata-vector-2", ordered[1].Id);
+        Assert.Equal([0, 1, 1, 2, 3, 5, 8, 13], ordered[1].Values);
+        Assert.Equal("metadata-vector-3", ordered[2].Id);
+        Assert.Equal([2, 1, 3, 4, 7, 11, 18, 29], ordered[2].Values);
+    }
+
+    [Fact]
+    public async Task Query_include_metadata_in_result()
+    {
+        var filter = new MetadataMap
+        {
+            ["subtype"] = "fibo"
+        };
+
+        var result = await Fixture.Index.Query([3, 4, 5, 6, 7, 8, 9, 10], topK: 5, filter, includeMetadata: true);
+
+        Assert.Single(result);
+        Assert.Equal("metadata-vector-2", result[0].Id);
+        Assert.Equal([0, 1, 1, 2, 3, 5, 8, 13], result[0].Values);
+        var metadata = result[0].Metadata;
+        Assert.NotNull(metadata);
+
+        Assert.Equal("number set",metadata["type"]);
+        Assert.Equal("fibo", metadata["subtype"]);
+
+        var innerList = (MetadataValue[])metadata["list"].Inner!;
+        Assert.Equal("0", innerList[0]);
+        Assert.Equal("1", innerList[1]);
+    }
+
+    [Fact]
+    public async Task Query_with_metadata_filter_composite()
+    {
+        var filter = new MetadataMap
+        {
+            ["type"] = "number set",
+            ["overhyped"] = false
+        };
+
+        var result = await Fixture.Index.Query([3, 4, 5, 6, 7, 8, 9, 10], topK: 5, filter);
+
+        Assert.Equal(2, result.Length);
+        var ordered = result.OrderBy(x => x.Id).ToList();
+
+        Assert.Equal("metadata-vector-1", ordered[0].Id);
+        Assert.Equal([2, 3, 5, 7, 11, 13, 17, 19], ordered[0].Values);
+        Assert.Equal("metadata-vector-3", ordered[1].Id);
+        Assert.Equal([2, 1, 3, 4, 7, 11, 18, 29], ordered[1].Values);
+    }
+
+    [Fact]
+    public async Task Query_with_metadata_list_contains()
+    {
+        var filter = new MetadataMap
+        {
+            ["rank"] = new MetadataMap() { ["$in"] = new int[] { 12, 3 } }
+        };
+
+        var result = await Fixture.Index.Query([3, 4, 5, 6, 7, 8, 9, 10], topK: 10, filter, includeMetadata: true);
+
+        Assert.Equal(2, result.Length);
+        var ordered = result.OrderBy(x => x.Id).ToList();
+
+        Assert.Equal("metadata-vector-1", ordered[0].Id);
+        Assert.Equal([2, 3, 5, 7, 11, 13, 17, 19], ordered[0].Values);
+        Assert.Equal("metadata-vector-3", ordered[1].Id);
+        Assert.Equal([2, 1, 3, 4, 7, 11, 18, 29], ordered[1].Values);
+    }
+
+    [Fact]
+    public async Task Basic_fetch()
+    {
+        var results = await Fixture.Index.Fetch(["basic-vector-1", "basic-vector-3"]);
+        var orderedResults = results.OrderBy(x => x.Key).ToList();
+        
+        Assert.Equal(2, orderedResults.Count);
+
+        Assert.Equal("basic-vector-1", orderedResults[0].Key);
+        Assert.Equal("basic-vector-1", orderedResults[0].Value.Id);
+        Assert.Equal([0.5f, 1.0f, 1.5f, 2.0f, 2.5f, 3.0f, 3.5f, 4.0f], orderedResults[0].Value.Values);
+
+        Assert.Equal("basic-vector-3", orderedResults[1].Key);
+        Assert.Equal("basic-vector-3", orderedResults[1].Value.Id);
+        Assert.Equal([1.5f, 3.0f, 4.5f, 6.0f, 7.5f, 9.0f, 10.5f, 12.0f], orderedResults[1].Value.Values);
+    }
+
+    [Fact]
+    public async Task Basic_vector_upsert_update_delete()
+    {
+        var testNamespace = "upsert-update-delete-namespace";
+        var newVectors = new Vector[]
+            {
+                new() { Id = "update-vector-id-1", Values = [1, 3, 5, 7, 9, 11, 13, 15] },
+                new() { Id = "update-vector-id-2", Values = [2, 3, 5, 7, 11, 13, 17, 19] },
+                new() { Id = "update-vector-id-3", Values = [2, 1, 3, 4, 7, 11, 18, 29] },
+            };
+
+        await Fixture.InsertAndWait(newVectors, testNamespace);
+
+        var initialFetch = await Fixture.Index.Fetch(["update-vector-id-2"], testNamespace);
+        var vector = initialFetch["update-vector-id-2"];
+        vector.Values[0] = 23;
+        await Fixture.Index.Update(vector, testNamespace);
+
+        Vector updatedVector;
+        var attemptCount = 0;
+        do
+        {
+            await Task.Delay(TestFixture.DelayInterval);
+            attemptCount++;
+            var finalFetch = await Fixture.Index.Fetch(["update-vector-id-2"], testNamespace);
+            updatedVector = finalFetch["update-vector-id-2"];
+        } while (updatedVector.Values[0] != 23 && attemptCount < TestFixture.MaxAttemptCount);
+
+        Assert.Equal("update-vector-id-2", updatedVector.Id);
+        Assert.Equal([23, 3, 5, 7, 11, 13, 17, 19], updatedVector.Values);
+
+        await Fixture.DeleteAndWait(["update-vector-id-1"], testNamespace);
+
+        var stats = await Fixture.Index.DescribeStats();
+        Assert.Equal((uint)2, stats.Namespaces.Where(x => x.Name == testNamespace).Select(x => x.VectorCount).SingleOrDefault());
+
+        await Fixture.DeleteAndWait(["update-vector-id-2", "update-vector-id-3"], testNamespace);
+    }
+
+    [Fact]
+    public async Task Upsert_on_existing_vector_makes_an_update()
+    {
+        var testNamespace = "upsert-on-existing";
+        var newVectors = new Vector[]
+            {
+                new() { Id = "update-vector-id-1", Values = [1, 3, 5, 7, 9, 11, 13, 15] },
+                new() { Id = "update-vector-id-2", Values = [2, 3, 5, 7, 11, 13, 17, 19] },
+                new() { Id = "update-vector-id-3", Values = [2, 1, 3, 4, 7, 11, 18, 29] },
+            };
+
+        await Fixture.InsertAndWait(newVectors, testNamespace);
+
+        var newExistingVector = new Vector() { Id = "update-vector-id-3", Values = [0, 1, 1, 2, 3, 5, 8, 13] };
+
+        await Fixture.Index.Upsert([newExistingVector], testNamespace);
+
+        Vector updatedVector;
+        var attemptCount = 0;
+        do
+        {
+            await Task.Delay(TestFixture.DelayInterval);
+            attemptCount++;
+            var finalFetch = await Fixture.Index.Fetch(["update-vector-id-3"], testNamespace);
+            updatedVector = finalFetch["update-vector-id-3"];
+        } while (updatedVector.Values[0] != 0 && attemptCount < TestFixture.MaxAttemptCount);
+
+        Assert.Equal("update-vector-id-3", updatedVector.Id);
+        Assert.Equal([0, 1, 1, 2, 3, 5, 8, 13], updatedVector.Values);
+    }
+
+    [Fact]
+    public async Task Delete_all_vectors_from_namespace()
+    {
+        var testNamespace = "delete-all-namespace";
+        var newVectors = new Vector[]
+            {
+                new() { Id = "delete-all-vector-id-1", Values = [1, 3, 5, 7, 9, 11, 13, 15] },
+                new() { Id = "delete-all-vector-id-2", Values = [2, 3, 5, 7, 11, 13, 17, 19] },
+                new() { Id = "delete-all-vector-id-3", Values = [2, 1, 3, 4, 7, 11, 18, 29] },
+            };
+
+        await Fixture.InsertAndWait(newVectors, testNamespace);
+
+        await Fixture.Index.DeleteAll(testNamespace);
+
+        IndexStats stats;
+        var attemptCount = 0;
+        do
+        {
+            await Task.Delay(TestFixture.DelayInterval);
+            attemptCount++;
+            stats = await Fixture.Index.DescribeStats();
+        } while (stats.Namespaces.Where(x => x.Name == testNamespace).Select(x => x.VectorCount).SingleOrDefault() > 0 
+            && attemptCount <= TestFixture.MaxAttemptCount);
+
+        Assert.Equal((uint)0, stats.Namespaces.Where(x => x.Name == testNamespace).Select(x => x.VectorCount).SingleOrDefault());
+    }
+
+    [Fact]
+    public async Task Delete_vector_that_doesnt_exist()
+    {
+        await Fixture.Index.Delete(["non-existing-index"]);
+    }
+
+    public class TestFixture : IAsyncLifetime
+    {
+        // 10s with 100ms intervals
+        public const int MaxAttemptCount = 100;
+        public const int DelayInterval = 100;
+        private const string IndexName = "serverless-data-tests";
+
+        public PineconeClient Pinecone { get; private set; } = null!;
+        public Index<GrpcTransport> Index { get; private set; } = null!;
+
+        public async Task InitializeAsync()
+        {
+            Pinecone = new PineconeClient(UserSecrets.Read("PineconeApiKey"));
+
+            await ClearIndexesAsync();
+            await CreateIndexAndWait();
+            await AddSampleDataAsync();
+        }
+
+        private async Task CreateIndexAndWait()
+        {
+            var attemptCount = 0;
+            await Pinecone.CreateServerlessIndexAsync(IndexName, dimiension: 8, metric: Metric.Euclidean, cloud: "aws", region: "us-east-1");
+
+            do
+            {
+                await Task.Delay(DelayInterval);
+                attemptCount++;
+                Index = await Pinecone.GetIndex(IndexName);
+            } while (!Index.Status.IsReady && attemptCount <= MaxAttemptCount);
+
+            if (!Index.Status.IsReady)
+            {
+                throw new InvalidOperationException("'Create index' operation didn't complete in time. Index name: " + IndexName);
+            }
+        }
+
+        private async Task AddSampleDataAsync()
+        {
+            var basicVectors = Enumerable.Range(1, 5).Select(i => new Vector
+            {
+                Id = "basic-vector-" + i,
+                Values = [i * 0.5f, i * 1.0f, i * 1.5f, i * 2.0f, i * 2.5f, i * 3.0f, i * 3.5f, i * 4.0f],
+            }).ToList();
+
+            await InsertAndWait(basicVectors);
+
+            var customNamespaceVectors = Enumerable.Range(1, 3).Select(i => new Vector
+            {
+                Id = "custom-namespace-vector-" + i,
+                Values = [i * 1.1f, i * 2.2f, i * 3.3f, i * 4.4f, i * 5.5f, i * 6.6f, i * 7.7f, i * 8.8f],
+            }).ToList();
+
+            await InsertAndWait(customNamespaceVectors, "namespace1");
+
+            var metadata1 = new MetadataMap
+            {
+                ["type"] = "number set",
+                ["subtype"] = "primes",
+                ["rank"] = 3,
+                ["overhyped"] = false,
+                ["list"] = new string[] { "2", "1" }, 
+            };
+
+            var metadata2 = new MetadataMap
+            {
+                ["type"] = "number set",
+                ["subtype"] = "fibo",
+                ["list"] = new string[] { "0", "1" },
+            };
+
+            var metadata3 = new MetadataMap
+            {
+                ["type"] = "number set",
+                ["subtype"] = "lucas",
+                ["rank"] = 12,
+                ["overhyped"] = false,
+                ["list"] = new string[] { "two", "one" },
+            };
+
+            var metadataVectors = new Vector[]
+            {
+                new() { Id = "metadata-vector-1", Values = [2, 3, 5, 7, 11, 13, 17, 19], Metadata = metadata1 },
+                new() { Id = "metadata-vector-2", Values = [0, 1, 1, 2, 3, 5, 8, 13], Metadata = metadata2 },
+                new() { Id = "metadata-vector-3", Values = [2, 1, 3, 4, 7, 11, 18, 29], Metadata = metadata3 },
+            };
+
+            await InsertAndWait(metadataVectors);
+        }
+
+        public async Task<uint> InsertAndWait(IEnumerable<Vector> vectors, string? indexNamespace = null)
+        {
+            // NOTE: this only works when inserting *new* vectors, if the vector already exisits the new vector count won't match
+            // and we will have false-negative "failure" to insert
+            var stats = await Index.DescribeStats();
+            var vectorCountBefore = stats.TotalVectorCount;
+            var attemptCount = 0;
+            var result = await Index.Upsert(vectors, indexNamespace);
+
+            do
+            {
+                await Task.Delay(DelayInterval);
+                attemptCount++;
+                stats = await Index.DescribeStats();
+            } while (stats.TotalVectorCount < vectorCountBefore + vectors.Count() && attemptCount <= MaxAttemptCount);
+
+            if (stats.TotalVectorCount < vectorCountBefore + vectors.Count())
+            {
+                throw new InvalidOperationException("'Upsert' operation didn't complete in time. Vectors count: " + vectors.Count());
+            }
+
+            return result;
+        }
+
+        public async Task DeleteAndWait(IEnumerable<string> ids, string? indexNamespace = null)
+        {
+            var stats = await Index.DescribeStats();
+            var vectorCountBefore = stats.Namespaces.Single(x => x.Name == (indexNamespace ?? "")).VectorCount;
+
+            var attemptCount = 0;
+            await Index.Delete(ids, indexNamespace);
+            long vectorCount;
+            do
+            {
+                await Task.Delay(DelayInterval);
+                attemptCount++;
+                stats = await Index.DescribeStats();
+                vectorCount = stats.Namespaces.Single(x => x.Name == (indexNamespace ?? "")).VectorCount;
+            } while (vectorCount > vectorCountBefore - ids.Count() && attemptCount <= MaxAttemptCount);
+
+            if (vectorCount > vectorCountBefore - ids.Count())
+            {
+                throw new InvalidOperationException("'Delete' operation didn't complete in time.");
+            }
+        }
+
+        public async Task DisposeAsync()
+        {
+            await ClearIndexesAsync();
+            Pinecone.Dispose();
+        }
+
+        private async Task ClearIndexesAsync()
+        {
+            foreach (var existingIndex in await Pinecone.ListIndexes())
+            {
+                await DeleteExistingIndexAndWaitAsync(existingIndex.Name);
+            }
+        }
+
+        private async Task DeleteExistingIndexAndWaitAsync(string indexName)
+        {
+            var exists = true;
+            var attemptCount = 0;
+            await Pinecone.DeleteIndex(indexName);
+
+            do
+            {
+                await Task.Delay(DelayInterval);
+                var indexes = (await Pinecone.ListIndexes()).Select(x => x.Name).ToArray();
+                if (indexes.Length == 0 || !indexes.Contains(indexName))
+                {
+                    exists = false;
+                }
+            } while (exists && attemptCount <= MaxAttemptCount);
+
+            if (exists)
+            {
+                throw new InvalidOperationException("'Delete index' operation didn't complete in time. Index name: " + indexName);
+            }
+        }
+    }
+}

--- a/test/DataTests.cs
+++ b/test/DataTests.cs
@@ -266,7 +266,7 @@ public class DataTests(DataTests.TestFixture fixture) : IClassFixture<DataTests.
         private async Task CreateIndexAndWait()
         {
             var attemptCount = 0;
-            await Pinecone.CreateServerlessIndexAsync(IndexName, dimiension: 8, metric: Metric.Euclidean, cloud: "aws", region: "us-east-1");
+            await Pinecone.CreateServerlessIndex(IndexName, dimiension: 8, metric: Metric.Euclidean, cloud: "aws", region: "us-east-1");
 
             do
             {

--- a/test/IndexTests.cs
+++ b/test/IndexTests.cs
@@ -1,0 +1,103 @@
+﻿using Pinecone;
+using Pinecone.Grpc;
+using Xunit;
+
+namespace PineconeTests;
+
+[Collection("PineconeTests")]
+public class IndexTests
+{
+    private const int MaxAttemptCount = 300;
+    private const int DelayInterval = 100;
+
+    [Fact]
+    public async Task Legacy_index_sandbox()
+    {
+        var indexName = "legacy-pod-based-index";
+
+        var pinecone = new PineconeClient(UserSecrets.Read("PineconeApiKey"));
+
+        // check all existing indexes
+        var podIndexes = (await pinecone.ListIndexes()).Where(x => x.Spec.Pod is not null).Select(x => x.Name).ToList();
+        foreach (var podIndex in podIndexes)
+        {
+            // delete the previous pod-based index (only one is allowed on free plan)
+            await pinecone.DeleteIndex(indexName);
+        }
+
+        var attemptCount = 0;
+        // wait until old index has been deleted
+        do
+        {
+            await Task.Delay(DelayInterval);
+            attemptCount++;
+            podIndexes = (await pinecone.ListIndexes()).Where(x => x.Spec.Pod is not null).Select(x => x.Name).ToList();
+        }
+        while (podIndexes.Any() && attemptCount < MaxAttemptCount);
+
+        //this will get created but initialization fails later
+        await pinecone.CreatePodIndexAsync(indexName, 3, Metric.Cosine, "gcp-starter", "starter", 1);
+
+        var listIndexes = await pinecone.ListIndexes();
+
+        Assert.Contains(indexName, listIndexes.Select(x => x.Name));
+    }
+
+    [Theory]
+    [InlineData(Metric.DotProduct)]
+    [InlineData(Metric.Cosine)]
+    [InlineData(Metric.Euclidean)]
+    public async Task Create_and_delete_serverless_index(Metric metric)
+    {
+        var indexName = "serverless-index";
+
+        var pinecone = new PineconeClient(UserSecrets.Read("PineconeApiKey"));
+
+        // check for existing index
+        var podIndexes = (await pinecone.ListIndexes()).Select(x => x.Name).ToList();
+        if (podIndexes.Contains(indexName))
+        {
+            // delete the previous index
+            await pinecone.DeleteIndex(indexName);
+        }
+
+        var attemptCount = 0;
+        // wait until old index has been deleted
+        do
+        {
+            await Task.Delay(DelayInterval);
+            attemptCount++;
+            podIndexes = (await pinecone.ListIndexes()).Select(x => x.Name).ToList();
+        }
+        while (podIndexes.Contains(indexName) && attemptCount < MaxAttemptCount);
+
+        await pinecone.CreateServerlessIndexAsync(indexName, 3, metric, "aws", "us-east-1");
+
+        Index<GrpcTransport> index;
+        attemptCount = 0;
+        do
+        {
+            await Task.Delay(DelayInterval);
+            attemptCount++;
+            index = await pinecone.GetIndex(indexName);
+        }
+        while (!index.Status.IsReady && attemptCount < MaxAttemptCount);
+
+        var listIndexes = await pinecone.ListIndexes();
+
+        // validate
+        Assert.Contains(indexName, listIndexes.Select(x => x.Name));
+        Assert.Equal((uint)3, index.Dimension);
+        Assert.Equal(metric, index.Metric);
+
+        // cleanup
+        await pinecone.DeleteIndex(indexName);
+    }
+
+    [Fact]
+    public async Task List_collections()
+    {
+        var pinecone = new PineconeClient(UserSecrets.Read("PineconeApiKey"));
+        var collections = await pinecone.ListCollections();
+    }
+}

--- a/test/IndexTests.cs
+++ b/test/IndexTests.cs
@@ -31,7 +31,6 @@ public class IndexTests
         {
             // delete the previous index
             await DeleteIndexAndWait(pinecone, indexName);
-            //await pinecone.DeleteIndex(indexName);
         }
 
         // if we create pod-based index, we need to delete any previous gcp-starter indexes

--- a/test/IndexTests.cs
+++ b/test/IndexTests.cs
@@ -51,7 +51,7 @@ public class IndexTests
         }
         else
         {
-            await pinecone.CreatePodBasedIndex(indexName, 3, metric, "gcp-starter", "starter", 1);
+            await pinecone.CreatePodBasedIndex(indexName, 3, metric, "gcp-starter");
         }
 
         Index<GrpcTransport> index;

--- a/test/IndexTests.cs
+++ b/test/IndexTests.cs
@@ -36,7 +36,7 @@ public class IndexTests
         while (podIndexes.Any() && attemptCount < MaxAttemptCount);
 
         //this will get created but initialization fails later
-        await pinecone.CreatePodIndexAsync(indexName, 3, Metric.Cosine, "gcp-starter", "starter", 1);
+        await pinecone.CreatePodBasedIndex(indexName, 3, Metric.Cosine, "gcp-starter", "starter", 1);
 
         var listIndexes = await pinecone.ListIndexes();
 
@@ -71,7 +71,7 @@ public class IndexTests
         }
         while (podIndexes.Contains(indexName) && attemptCount < MaxAttemptCount);
 
-        await pinecone.CreateServerlessIndexAsync(indexName, 3, metric, "aws", "us-east-1");
+        await pinecone.CreateServerlessIndex(indexName, 3, metric, "aws", "us-east-1");
 
         Index<GrpcTransport> index;
         attemptCount = 0;

--- a/test/PineconeTests.csproj
+++ b/test/PineconeTests.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
     <WarningsAsErrors>nullable</WarningsAsErrors>
-    <IsAotCompatible>true</IsAotCompatible>
     <ImplicitUsings>enable</ImplicitUsings>
     <LangVersion>12</LangVersion>
     <Nullable>enable</Nullable>

--- a/test/PineconeTests.csproj
+++ b/test/PineconeTests.csproj
@@ -1,0 +1,29 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+    <WarningsAsErrors>nullable</WarningsAsErrors>
+    <IsAotCompatible>true</IsAotCompatible>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <LangVersion>12</LangVersion>
+    <Nullable>enable</Nullable>
+    <RootNamespace>PineconeTests</RootNamespace>
+    <UserSecretsId>1af43fd0-bcf9-4d57-89db-d842f94175a2</UserSecretsId>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>   
+    </PackageReference>
+    <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
+  </ItemGroup>
+  
+  <ItemGroup>
+    <ProjectReference Include="..\src\Pinecone.csproj" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="8.0.0" />
+  </ItemGroup>
+
+</Project>

--- a/test/PodBasedDataTests.cs
+++ b/test/PodBasedDataTests.cs
@@ -15,7 +15,7 @@ public class PodBasedDataTests(PodBasedDataTests.PodBasedDataTestFixture fixture
         protected override async Task CreateIndexAndWait()
         {
             var attemptCount = 0;
-            await Pinecone.CreatePodBasedIndex(IndexName, dimension: 8, metric: Metric.Cosine, environment: "gcp-starter", podType: "starter", pods: 1);
+            await Pinecone.CreatePodBasedIndex(IndexName, dimension: 8, metric: Metric.DotProduct, environment: "gcp-starter");
 
             do
             {

--- a/test/PodBasedDataTests.cs
+++ b/test/PodBasedDataTests.cs
@@ -1,0 +1,33 @@
+﻿using Pinecone;
+using PineconeTests.Xunit;
+using Xunit;
+
+namespace PineconeTests;
+
+[Collection("PineconeTests")]
+[PineconeApiKeySetCondition]
+public class PodBasedDataTests(PodBasedDataTests.PodBasedDataTestFixture fixture) : DataTestBase<PodBasedDataTests.PodBasedDataTestFixture>(fixture)
+{
+    public class PodBasedDataTestFixture : DataTestFixtureBase
+    {
+        protected override string IndexName => "pod-data-tests";
+
+        protected override async Task CreateIndexAndWait()
+        {
+            var attemptCount = 0;
+            await Pinecone.CreatePodBasedIndex(IndexName, dimension: 8, metric: Metric.Cosine, environment: "gcp-starter", podType: "starter", pods: 1);
+
+            do
+            {
+                await Task.Delay(DelayInterval);
+                attemptCount++;
+                Index = await Pinecone.GetIndex(IndexName);
+            } while (!Index.Status.IsReady && attemptCount <= MaxAttemptCount);
+
+            if (!Index.Status.IsReady)
+            {
+                throw new InvalidOperationException("'Create index' operation didn't complete in time. Index name: " + IndexName);
+            }
+        }
+    }
+}

--- a/test/ServerlessDataTests.cs
+++ b/test/ServerlessDataTests.cs
@@ -1,0 +1,33 @@
+﻿using Pinecone;
+using PineconeTests.Xunit;
+using Xunit;
+
+namespace PineconeTests;
+
+[Collection("PineconeTests")]
+[PineconeApiKeySetCondition]
+public class ServerlessDataTests(ServerlessDataTests.ServerlessDataTestFixture fixture) : DataTestBase<ServerlessDataTests.ServerlessDataTestFixture>(fixture)
+{
+    public class ServerlessDataTestFixture : DataTestFixtureBase
+    {
+        protected override string IndexName => "serverless-data-tests";
+
+        protected override async Task CreateIndexAndWait()
+        {
+            var attemptCount = 0;
+            await Pinecone.CreateServerlessIndex(IndexName, dimension: 8, metric: Metric.Cosine, cloud: "aws", region: "us-east-1");
+
+            do
+            {
+                await Task.Delay(DelayInterval);
+                attemptCount++;
+                Index = await Pinecone.GetIndex(IndexName);
+            } while (!Index.Status.IsReady && attemptCount <= MaxAttemptCount);
+
+            if (!Index.Status.IsReady)
+            {
+                throw new InvalidOperationException("'Create index' operation didn't complete in time. Index name: " + IndexName);
+            }
+        }
+    }
+}

--- a/test/ServerlessDataTests.cs
+++ b/test/ServerlessDataTests.cs
@@ -15,7 +15,7 @@ public class ServerlessDataTests(ServerlessDataTests.ServerlessDataTestFixture f
         protected override async Task CreateIndexAndWait()
         {
             var attemptCount = 0;
-            await Pinecone.CreateServerlessIndex(IndexName, dimension: 8, metric: Metric.Cosine, cloud: "aws", region: "us-east-1");
+            await Pinecone.CreateServerlessIndex(IndexName, dimension: 8, metric: Metric.DotProduct, cloud: "aws", region: "us-east-1");
 
             do
             {

--- a/test/UserSecretsExtensions.cs
+++ b/test/UserSecretsExtensions.cs
@@ -1,0 +1,14 @@
+﻿using System.Reflection;
+using System.Text.Json;
+using Microsoft.Extensions.Configuration.UserSecrets;
+
+namespace PineconeTests;
+
+public class UserSecrets
+{
+    public static string Read(string key)
+        => JsonSerializer.Deserialize<Dictionary<string, string>>(
+            File.ReadAllText(PathHelper.GetSecretsPathFromSecretsId(
+                typeof(UserSecrets).Assembly.GetCustomAttribute<UserSecretsIdAttribute>()!
+                    .UserSecretsId)))![key];
+}

--- a/test/UserSecretsExtensions.cs
+++ b/test/UserSecretsExtensions.cs
@@ -15,8 +15,15 @@ public static class UserSecretsExtensions
                     .UserSecretsId)))![PineconeApiKeyUserSecretEntry];
 
     public static bool ContainsPineconeApiKey()
-        => JsonSerializer.Deserialize<Dictionary<string, string>>(
+    {
+        var userSecretsIdAttribute = typeof(UserSecretsExtensions).Assembly.GetCustomAttribute<UserSecretsIdAttribute>();
+        if (userSecretsIdAttribute == null)
+        {
+            return false;
+        }
+
+        return JsonSerializer.Deserialize<Dictionary<string, string>>(
             File.ReadAllText(PathHelper.GetSecretsPathFromSecretsId(
-                typeof(UserSecretsExtensions).Assembly.GetCustomAttribute<UserSecretsIdAttribute>()!
-                    .UserSecretsId)))!.ContainsKey(PineconeApiKeyUserSecretEntry);
+                userSecretsIdAttribute.UserSecretsId)))!.ContainsKey(PineconeApiKeyUserSecretEntry);
+    }
 }

--- a/test/UserSecretsExtensions.cs
+++ b/test/UserSecretsExtensions.cs
@@ -22,8 +22,13 @@ public static class UserSecretsExtensions
             return false;
         }
 
+        var path = PathHelper.GetSecretsPathFromSecretsId(userSecretsIdAttribute.UserSecretsId);
+        if (!File.Exists(path))
+        {
+            return false;
+        }
+
         return JsonSerializer.Deserialize<Dictionary<string, string>>(
-            File.ReadAllText(PathHelper.GetSecretsPathFromSecretsId(
-                userSecretsIdAttribute.UserSecretsId)))!.ContainsKey(PineconeApiKeyUserSecretEntry);
+            File.ReadAllText(path))!.ContainsKey(PineconeApiKeyUserSecretEntry);
     }
 }

--- a/test/UserSecretsExtensions.cs
+++ b/test/UserSecretsExtensions.cs
@@ -4,11 +4,19 @@ using Microsoft.Extensions.Configuration.UserSecrets;
 
 namespace PineconeTests;
 
-public class UserSecrets
+public static class UserSecretsExtensions
 {
-    public static string Read(string key)
+    public const string PineconeApiKeyUserSecretEntry = "PineconeApiKey";
+
+    public static string ReadPineconeApiKey()
         => JsonSerializer.Deserialize<Dictionary<string, string>>(
             File.ReadAllText(PathHelper.GetSecretsPathFromSecretsId(
-                typeof(UserSecrets).Assembly.GetCustomAttribute<UserSecretsIdAttribute>()!
-                    .UserSecretsId)))![key];
+                typeof(UserSecretsExtensions).Assembly.GetCustomAttribute<UserSecretsIdAttribute>()!
+                    .UserSecretsId)))![PineconeApiKeyUserSecretEntry];
+
+    public static bool ContainsPineconeApiKey()
+        => JsonSerializer.Deserialize<Dictionary<string, string>>(
+            File.ReadAllText(PathHelper.GetSecretsPathFromSecretsId(
+                typeof(UserSecretsExtensions).Assembly.GetCustomAttribute<UserSecretsIdAttribute>()!
+                    .UserSecretsId)))!.ContainsKey(PineconeApiKeyUserSecretEntry);
 }

--- a/test/Xunit/ITestCondition.cs
+++ b/test/Xunit/ITestCondition.cs
@@ -1,0 +1,8 @@
+﻿namespace PineconeTests.Xunit;
+
+public interface ITestCondition
+{
+    ValueTask<bool> IsMetAsync();
+
+    string SkipReason { get; }
+}

--- a/test/Xunit/PineconeApiKeySetConditionAttribute.cs
+++ b/test/Xunit/PineconeApiKeySetConditionAttribute.cs
@@ -1,0 +1,14 @@
+﻿namespace PineconeTests.Xunit;
+
+public sealed class PineconeApiKeySetConditionAttribute : Attribute, ITestCondition
+{
+    public ValueTask<bool> IsMetAsync()
+    {
+        var isMet = UserSecretsExtensions.ContainsPineconeApiKey();
+
+        return ValueTask.FromResult(isMet);
+    }
+
+    public string SkipReason
+        => $"Pinecone API key was not specified in user secrets. Use the following command to set it: dotnet user-secrets set \"{UserSecretsExtensions.PineconeApiKeyUserSecretEntry}\" \"[your Pinecone API key]\"";
+}

--- a/test/Xunit/PineconeFactAttribute.cs
+++ b/test/Xunit/PineconeFactAttribute.cs
@@ -1,0 +1,8 @@
+﻿using Xunit;
+using Xunit.Sdk;
+
+namespace PineconeTests.Xunit;
+
+[AttributeUsage(AttributeTargets.Method)]
+[XunitTestCaseDiscoverer("PineconeTests.Xunit.PineconeFactDiscoverer", "PineconeTests")]
+public sealed class PineconeFactAttribute : FactAttribute;

--- a/test/Xunit/PineconeFactDiscoverer.cs
+++ b/test/Xunit/PineconeFactDiscoverer.cs
@@ -1,0 +1,17 @@
+﻿using Xunit.Abstractions;
+using Xunit.Sdk;
+
+namespace PineconeTests.Xunit;
+
+public class PineconeFactDiscoverer(IMessageSink messageSink) : FactDiscoverer(messageSink)
+{
+    protected override IXunitTestCase CreateTestCase(
+        ITestFrameworkDiscoveryOptions discoveryOptions,
+        ITestMethod testMethod,
+        IAttributeInfo factAttribute)
+        => new PineconeFactTestCase(
+            DiagnosticMessageSink,
+            discoveryOptions.MethodDisplayOrDefault(),
+            discoveryOptions.MethodDisplayOptionsOrDefault(),
+            testMethod);
+}

--- a/test/Xunit/PineconeFactTestCase.cs
+++ b/test/Xunit/PineconeFactTestCase.cs
@@ -1,0 +1,37 @@
+﻿using Xunit.Abstractions;
+using Xunit.Sdk;
+
+namespace PineconeTests.Xunit;
+
+public sealed class PineconeFactTestCase : XunitTestCase
+{
+    [Obsolete("Called by the de-serializer; should only be called by deriving classes for de-serialization purposes")]
+    public PineconeFactTestCase()
+    {
+    }
+
+    public PineconeFactTestCase(
+        IMessageSink diagnosticMessageSink,
+        TestMethodDisplay defaultMethodDisplay,
+        TestMethodDisplayOptions defaultMethodDisplayOptions,
+        ITestMethod testMethod,
+        object[]? testMethodArguments = null)
+        : base(diagnosticMessageSink, defaultMethodDisplay, defaultMethodDisplayOptions, testMethod, testMethodArguments)
+    {
+    }
+
+    public override async Task<RunSummary> RunAsync(
+        IMessageSink diagnosticMessageSink,
+        IMessageBus messageBus,
+        object[] constructorArguments,
+        ExceptionAggregator aggregator,
+        CancellationTokenSource cancellationTokenSource)
+        => await XunitTestCaseExtensions.TrySkipAsync(this, messageBus)
+            ? new RunSummary { Total = 1, Skipped = 1 }
+            : await base.RunAsync(
+                diagnosticMessageSink,
+                messageBus,
+                constructorArguments,
+                aggregator,
+                cancellationTokenSource);
+}

--- a/test/Xunit/PineconeFactTestCase.cs
+++ b/test/Xunit/PineconeFactTestCase.cs
@@ -25,7 +25,7 @@ public sealed class PineconeFactTestCase : XunitTestCase
         IMessageBus messageBus,
         object[] constructorArguments,
         ExceptionAggregator aggregator,
-        CancellationTokenSource cancellationTokenSource)
+        CancellationTokenSource ctSource)
         => await XunitTestCaseExtensions.TrySkipAsync(this, messageBus)
             ? new RunSummary { Total = 1, Skipped = 1 }
             : await base.RunAsync(
@@ -33,5 +33,5 @@ public sealed class PineconeFactTestCase : XunitTestCase
                 messageBus,
                 constructorArguments,
                 aggregator,
-                cancellationTokenSource);
+                ctSource);
 }

--- a/test/Xunit/PineconeTheoryAttribute.cs
+++ b/test/Xunit/PineconeTheoryAttribute.cs
@@ -1,0 +1,8 @@
+﻿using Xunit;
+using Xunit.Sdk;
+
+namespace PineconeTests.Xunit;
+
+[AttributeUsage(AttributeTargets.Method)]
+[XunitTestCaseDiscoverer("PineconeTests.Xunit.PineconeTheoryDiscoverer", "PineconeTests")]
+public sealed class PineconeTheoryAttribute : TheoryAttribute;

--- a/test/Xunit/PineconeTheoryDiscoverer.cs
+++ b/test/Xunit/PineconeTheoryDiscoverer.cs
@@ -1,0 +1,33 @@
+﻿using Xunit.Abstractions;
+using Xunit.Sdk;
+
+namespace PineconeTests.Xunit;
+
+public class PineconeTheoryDiscoverer(IMessageSink messageSink) : TheoryDiscoverer(messageSink)
+{
+    protected override IEnumerable<IXunitTestCase> CreateTestCasesForTheory(
+        ITestFrameworkDiscoveryOptions discoveryOptions,
+        ITestMethod testMethod,
+        IAttributeInfo theoryAttribute)
+    {
+        yield return new PineconeTheoryTestCase(
+            DiagnosticMessageSink,
+            discoveryOptions.MethodDisplayOrDefault(),
+            discoveryOptions.MethodDisplayOptionsOrDefault(),
+            testMethod);
+    }
+
+    protected override IEnumerable<IXunitTestCase> CreateTestCasesForDataRow(
+        ITestFrameworkDiscoveryOptions discoveryOptions,
+        ITestMethod testMethod,
+        IAttributeInfo theoryAttribute,
+        object[] dataRow)
+    {
+        yield return new PineconeFactTestCase(
+            DiagnosticMessageSink,
+            discoveryOptions.MethodDisplayOrDefault(),
+            discoveryOptions.MethodDisplayOptionsOrDefault(),
+            testMethod,
+            dataRow);
+    }
+}

--- a/test/Xunit/PineconeTheoryTestCase.cs
+++ b/test/Xunit/PineconeTheoryTestCase.cs
@@ -23,7 +23,7 @@ public sealed class PineconeTheoryTestCase : XunitTheoryTestCase
         IMessageBus messageBus,
         object[] constructorArguments,
         ExceptionAggregator aggregator,
-        CancellationTokenSource cancellationTokenSource)
+        CancellationTokenSource ctSource)
         => await XunitTestCaseExtensions.TrySkipAsync(this, messageBus)
             ? new RunSummary { Total = 1, Skipped = 1 }
             : await base.RunAsync(
@@ -31,5 +31,5 @@ public sealed class PineconeTheoryTestCase : XunitTheoryTestCase
                 messageBus,
                 constructorArguments,
                 aggregator,
-                cancellationTokenSource);
+                ctSource);
 }

--- a/test/Xunit/PineconeTheoryTestCase.cs
+++ b/test/Xunit/PineconeTheoryTestCase.cs
@@ -1,0 +1,35 @@
+﻿using PineconeTests.Xunit;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+public sealed class PineconeTheoryTestCase : XunitTheoryTestCase
+{
+    [Obsolete("Called by the de-serializer; should only be called by deriving classes for de-serialization purposes")]
+    public PineconeTheoryTestCase()
+    {
+    }
+
+    public PineconeTheoryTestCase(
+        IMessageSink diagnosticMessageSink,
+        TestMethodDisplay defaultMethodDisplay,
+        TestMethodDisplayOptions defaultMethodDisplayOptions,
+        ITestMethod testMethod)
+        : base(diagnosticMessageSink, defaultMethodDisplay, defaultMethodDisplayOptions, testMethod)
+    {
+    }
+
+    public override async Task<RunSummary> RunAsync(
+        IMessageSink diagnosticMessageSink,
+        IMessageBus messageBus,
+        object[] constructorArguments,
+        ExceptionAggregator aggregator,
+        CancellationTokenSource cancellationTokenSource)
+        => await XunitTestCaseExtensions.TrySkipAsync(this, messageBus)
+            ? new RunSummary { Total = 1, Skipped = 1 }
+            : await base.RunAsync(
+                diagnosticMessageSink,
+                messageBus,
+                constructorArguments,
+                aggregator,
+                cancellationTokenSource);
+}

--- a/test/Xunit/XunitTestCaseExtensions.cs
+++ b/test/Xunit/XunitTestCaseExtensions.cs
@@ -1,0 +1,49 @@
+﻿using System.Collections.Concurrent;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+namespace PineconeTests.Xunit;
+
+public static class XunitTestCaseExtensions
+{
+    private static readonly ConcurrentDictionary<string, List<IAttributeInfo>> _typeAttributes = new();
+    private static readonly ConcurrentDictionary<string, List<IAttributeInfo>> _assemblyAttributes = new();
+
+    public static async ValueTask<bool> TrySkipAsync(XunitTestCase testCase, IMessageBus messageBus)
+    {
+        var method = testCase.Method;
+        var type = testCase.TestMethod.TestClass.Class;
+        var assembly = type.Assembly;
+
+        var skipReasons = new List<string>();
+        var attributes =
+            _assemblyAttributes.GetOrAdd(
+                    assembly.Name,
+                    a => assembly.GetCustomAttributes(typeof(ITestCondition)).ToList())
+                .Concat(
+                    _typeAttributes.GetOrAdd(
+                        type.Name,
+                        t => type.GetCustomAttributes(typeof(ITestCondition)).ToList()))
+                .Concat(method.GetCustomAttributes(typeof(ITestCondition)))
+                .OfType<ReflectionAttributeInfo>()
+                .Select(attributeInfo => (ITestCondition)attributeInfo.Attribute);
+
+        foreach (var attribute in attributes)
+        {
+            if (!await attribute.IsMetAsync())
+            {
+                skipReasons.Add(attribute.SkipReason);
+            }
+        }
+
+        if (skipReasons.Count > 0)
+        {
+            messageBus.QueueMessage(
+                new TestSkipped(new XunitTest(testCase, testCase.DisplayName), string.Join(Environment.NewLine, skipReasons)));
+            
+            return true;
+        }
+
+        return false;
+    }
+}


### PR DESCRIPTION
- Adding support for serverless indexes
- Moving to new global API (also list indexes and list collections now return more data)
- Adding tests (local testing story is not available so using free option - in order to run tests you need to add your API key to the user secrets - https://learn.microsoft.com/en-us/aspnet/core/security/app-secrets?view=aspnetcore-8.0&tabs=windows#set-a-secret)
- Minor API fixes to more accurately reflect the API spec

Fixes #91
Fixes #107

Lot of breaking changes here - there are significant differences between old and new APIs, also pod vs serverless Tests run against both pod and serverless using the free plan. Functionality not available in this plan has not been tested.

NOT TESTED (requires paid plan):
- create collection from index,
- restore index from collection,
- list collections (when there is something in them),
- pod-based index modifications (upscaling, downscaling)
- delete vectors based on filter