### PR TITLE
Add support for netstandard2.0

### DIFF
--- a/src/Compatibility/ExtensionMethods.cs
+++ b/src/Compatibility/ExtensionMethods.cs
@@ -1,0 +1,13 @@
+﻿namespace System.Linq
+{
+#if NETSTANDARD2_0
+    public static class ExtensionMethods
+    {
+        public static void Deconstruct<T1, T2>(this KeyValuePair<T1, T2> tuple, out T1 key, out T2 value)
+        {
+            key = tuple.Key;
+            value = tuple.Value;
+        }
+    }
+#endif
+}

--- a/src/Compatibility/RuntimeHelpers.cs
+++ b/src/Compatibility/RuntimeHelpers.cs
@@ -1,0 +1,35 @@
+﻿namespace System.Runtime.CompilerServices
+{
+#if NETSTANDARD2_0
+    internal static class RuntimeHelpers
+    {
+        public static T[] GetSubArray<T>(T[] array, Range range)
+        {
+            if (array == null)
+            {
+                throw new ArgumentNullException();
+            }
+
+            (int offset, int length) = range.GetOffsetAndLength(array.Length);
+
+            if (default(T)! != null || typeof(T[]) == array.GetType())
+            {
+                if (length == 0)
+                {
+                    return Array.Empty<T>();
+                }
+
+                var dest = new T[length];
+                Array.Copy(array, offset, dest, 0, length);
+                return dest;
+            }
+            else
+            {
+                T[] dest = (T[])Array.CreateInstance(array.GetType().GetElementType()!, length);
+                Array.Copy(array, offset, dest, 0, length);
+                return dest;
+            }
+        }
+    }
+#endif
+}

--- a/src/Extensions.cs
+++ b/src/Extensions.cs
@@ -10,14 +10,23 @@ internal static class Extensions
     internal static ValueTask CheckStatusCode(
         this HttpResponseMessage response, CancellationToken ct, [CallerMemberName] string requestName = "")
     {
+#if NETSTANDARD2_0
+        return response.IsSuccessStatusCode ? default : ThrowOnFailedResponse(response, requestName, ct);
+#else
         return response.IsSuccessStatusCode ? ValueTask.CompletedTask : ThrowOnFailedResponse(response, requestName, ct);
+#endif
 
         [DoesNotReturn, StackTraceHidden]
         static async ValueTask ThrowOnFailedResponse(
             HttpResponseMessage response, string requestName, CancellationToken ct)
         {
+
             throw new HttpRequestException($"{requestName} request has failed. " +
+#if NETSTANDARD2_0
+                $"Code: {response.StatusCode}. Message: {await response.Content.ReadAsStringAsync().ConfigureAwait(false)}");
+#else
                 $"Code: {response.StatusCode}. Message: {await response.Content.ReadAsStringAsync(ct).ConfigureAwait(false)}");
+#endif
         }
     }
 }

--- a/src/ITransport.cs
+++ b/src/ITransport.cs
@@ -13,7 +13,7 @@ public interface ITransport<
 {
 #if NET7_0_OR_GREATER
     static abstract T Create(string host, string apiKey);
-#else
+#elif !NETSTANDARD2_0
     static T Create(string host, string apiKey)
     {
         if (typeof(T) == typeof(GrpcTransport))

--- a/src/Index.cs
+++ b/src/Index.cs
@@ -148,6 +148,7 @@ public sealed partial record Index<TTransport> : IDisposable
         string? indexNamespace = null,
         CancellationToken ct = default)
     {
+#if !NETSTANDARD2_0
         const int batchSize = 100;
         const int parallelism = 20;
         const int threshold = 400;
@@ -156,10 +157,12 @@ public sealed partial record Index<TTransport> : IDisposable
         {
             return Upsert(vectors, batchSize, parallelism, indexNamespace, ct);
         }
+#endif
 
         return Transport.Upsert(vectors, indexNamespace, ct);
     }
 
+#if !NETSTANDARD2_0
     /// <summary>
     /// Writes vectors into the index as batches in parallel. If a new value is provided for an existing vector ID, it will overwrite the previous value.
     /// </summary>
@@ -200,6 +203,7 @@ public sealed partial record Index<TTransport> : IDisposable
 
         return upserted;
     }
+#endif
 
     /// <summary>
     /// Updates a vector using the <see cref="Vector"/> object.
@@ -242,6 +246,7 @@ public sealed partial record Index<TTransport> : IDisposable
     /// <returns>A dictionary containing vector IDs and the corresponding <see cref="Vector"/> objects containing the vector information.</returns>
     public Task<Dictionary<string, Vector>> Fetch(IEnumerable<string> ids, string? indexNamespace = null, CancellationToken ct = default)
     {
+#if !NETSTANDARD2_0
         const int batchSize = 200;
         const int parallelism = 20;
         const int threshold = 600;
@@ -250,10 +255,12 @@ public sealed partial record Index<TTransport> : IDisposable
         {
             return Fetch(ids, batchSize, parallelism, indexNamespace, ct);
         }
+#endif
 
         return Transport.Fetch(ids, indexNamespace, ct);
     }
 
+#if !NETSTANDARD2_0
     /// <summary>
     /// Looks up and returns vectors by ID as batches in parallel.
     /// </summary>
@@ -292,6 +299,7 @@ public sealed partial record Index<TTransport> : IDisposable
 
         return new(fetched.SelectMany(batch => batch));
     }
+#endif
 
     /// <summary>
     /// Deletes vectors with specified ids.

--- a/src/Pinecone.csproj
+++ b/src/Pinecone.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <PackageId>Pinecone.NET</PackageId>
@@ -13,7 +13,7 @@ In the absence of an official SDK, it provides first-class support for Pinecone 
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0;net8.0;netstandard2.0</TargetFrameworks>
     <WarningsAsErrors>nullable</WarningsAsErrors>
     <IsAotCompatible>true</IsAotCompatible>
     <ImplicitUsings>enable</ImplicitUsings>
@@ -23,11 +23,11 @@ In the absence of an official SDK, it provides first-class support for Pinecone 
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(TargetFramework)' == 'net6.0'">
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net6.0' Or '$(TargetFramework)' == 'netstandard2.0'">
     <PolySharpIncludeRuntimeSupportedAttributes>true</PolySharpIncludeRuntimeSupportedAttributes>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net7.0' Or '$(TargetFramework)' == 'net6.0'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net7.0' Or '$(TargetFramework)' == 'net6.0' Or '$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="System.Net.Http.Json" Version="8.0.0" />
     <PackageReference Include="System.Text.Json" Version="8.0.3" />
     <PackageReference Include="PolySharp" Version="1.14.1">

--- a/src/Rest/Converters.cs
+++ b/src/Rest/Converters.cs
@@ -57,7 +57,11 @@ public class IndexNamespaceArrayConverter : JsonConverter<IndexNamespace[]>
                     ThrowHelper.ThrowFormatException("Expected number value");
                 }
 
+#if !NETSTANDARD2_0
                 buffer.Add(new() { Name = Encoding.UTF8.GetString(nameSpan), VectorCount = reader.GetUInt32() });
+#else
+                buffer.Add(new() { Name = Encoding.UTF8.GetString(nameSpan.ToArray()), VectorCount = reader.GetUInt32() });
+#endif
             }
         }
 

--- a/src/Types/VectorTypes.cs
+++ b/src/Types/VectorTypes.cs
@@ -91,7 +91,13 @@ public sealed class MetadataMap : Dictionary<string, MetadataValue>
     /// Creates a new instance of the <see cref="MetadataMap" /> class from an existing collection.
     /// </summary>
     /// <param name="collection"></param>
-    public MetadataMap(IEnumerable<KeyValuePair<string, MetadataValue>> collection) : base(collection) { }
+    public MetadataMap(IEnumerable<KeyValuePair<string, MetadataValue>> collection)
+#if NETSTANDARD2_0
+        : base(collection.ToDictionary(e => e.Key, e => e.Value))
+#else
+        : base(collection)
+#endif
+    { }
 }
 
 /// <summary>


### PR DESCRIPTION
First stab at the problem. Still work in progress but looks promising. Pretty much the only break is the explicit interface implementation / static abstract method on the ITransport (needs runtime changes so no way to hack it into ns2) and the new parallelization logic (Parallel.ForEachAsync). Chunk is bit much as well. Apart from that Index and Range are the only relatively complicated code that needed to be ported/copied.

I still haven't run any tests on ns2, but all the tests on 6, 7 and 8 pass without issue. 